### PR TITLE
#4516

### DIFF
--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDao.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDao.java
@@ -132,7 +132,12 @@ public class CustomerOnlinePaymentBusinessTransactionDao {
      *
      * @return DatabaseTable
      */
-    private DatabaseTable getDatabaseEventsTable() {
+    /**
+     * Access modifier was changed from private to protected to enhance
+     * testability
+     */
+    // private
+    protected DatabaseTable getDatabaseEventsTable() {
         return getDataBase().getTable(
                 CustomerOnlinePaymentBusinessTransactionDatabaseConstants.ONLINE_PAYMENT_EVENTS_RECORDED_TABLE_NAME);
     }
@@ -163,6 +168,7 @@ public class CustomerOnlinePaymentBusinessTransactionDao {
             DatabaseTable databaseTable=getDatabaseEventsTable();
             List<String> eventTypeList=new ArrayList<>();
             String eventId;
+
             databaseTable.addStringFilter(
                     CustomerOnlinePaymentBusinessTransactionDatabaseConstants.ONLINE_PAYMENT_EVENTS_RECORDED_STATUS_COLUMN_NAME,
                     EventStatus.PENDING.getCode(),
@@ -291,7 +297,7 @@ public class CustomerOnlinePaymentBusinessTransactionDao {
         }
     }
 
-        public List<BusinessTransactionRecord> getOnCryptoNetworkCryptoStatusList() throws
+    public List<BusinessTransactionRecord> getOnCryptoNetworkCryptoStatusList() throws
             UnexpectedResultReturnedFromDatabaseException,
             CantGetContractListException {
         try{
@@ -530,7 +536,6 @@ public class CustomerOnlinePaymentBusinessTransactionDao {
     public BusinessTransactionRecord getCustomerOnlinePaymentRecord(String contractHash) throws UnexpectedResultReturnedFromDatabaseException {
 
         try{
-            System.out.println("1");
             DatabaseTable databaseTable=getDatabaseContractTable();
             ContractTransactionStatus contractTransactionStatus;
             CryptoAddress brokerCryptoAddress;
@@ -816,7 +821,6 @@ public class CustomerOnlinePaymentBusinessTransactionDao {
             UnexpectedResultReturnedFromDatabaseException,
             CantUpdateRecordException {
         try{
-            System.out.println("123");
             updateRecordStatus(contractHash,
                     CustomerOnlinePaymentBusinessTransactionDatabaseConstants.ONLINE_PAYMENT_CONTRACT_HASH_COLUMN_NAME,
                     contractTransactionStatus.getCode());

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getOnCryptoNetworkCryptoStatusListTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getOnCryptoNetworkCryptoStatusListTest.java
@@ -1,0 +1,49 @@
+package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDaoTest;
+
+import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 05/02/16.
+ */
+public class getOnCryptoNetworkCryptoStatusListTest {
+    @Mock
+    private PluginDatabaseSystem mockPluginDatabaseSystem;
+    @Mock
+    private Database mockDatabase;
+    @Mock
+    DatabaseTable databaseTable;
+    private UUID testId;
+    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDao;
+    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDaoSpy;
+
+
+    @Before
+    public void setup()throws Exception{
+        testId = UUID.randomUUID();
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase);
+        customerOnlinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOnlinePaymentBusinessTransactionDao);
+        MockitoAnnotations.initMocks(this);
+        PowerMockito.doReturn(databaseTable).when(customerOnlinePaymentBusinessTransactionDaoSpy, "getDatabaseContractTable");
+    }
+    @Test
+    public void getOnCryptoNetworkCryptoStatusListTest_Should_Return_Not_Null()throws Exception{
+        assertNotNull(customerOnlinePaymentBusinessTransactionDaoSpy.getOnCryptoNetworkCryptoStatusList());
+    }
+    @Test(expected = Exception.class)
+    public void getOnCryptoNetworkCryptoStatusListTest_Should_Throw_Exception()throws Exception{
+        customerOnlinePaymentBusinessTransactionDao.getOnCryptoNetworkCryptoStatusList();
+    }
+}

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getPendingEventsTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getPendingEventsTest.java
@@ -1,0 +1,48 @@
+package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDaoTest;
+
+import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+
+import java.util.UUID;
+
+/**
+ * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 05/02/16.
+ */
+public class getPendingEventsTest {
+    @Mock
+    private PluginDatabaseSystem mockPluginDatabaseSystem;
+    @Mock
+    private Database mockDatabase;
+    @Mock
+    DatabaseTable databaseTable;
+    private UUID testId;
+    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDao;
+    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDaoSpy;
+
+
+    @Before
+    public void setup()throws Exception{
+        testId = UUID.randomUUID();
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase);
+        customerOnlinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOnlinePaymentBusinessTransactionDao);
+        MockitoAnnotations.initMocks(this);
+        PowerMockito.doReturn(databaseTable).when(customerOnlinePaymentBusinessTransactionDaoSpy, "getDatabaseEventsTable");
+    }
+
+    @Test
+    public void getPendingEventsTest_Should_Return_Empty_List() throws Exception{
+        customerOnlinePaymentBusinessTransactionDaoSpy.getPendingEvents();
+    }
+    @Test(expected = Exception.class)
+    public void getPendingEventsTest_Should_Throw_Exception() throws Exception{
+        customerOnlinePaymentBusinessTransactionDao.getPendingEvents();
+    }
+}

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getPendingToSubmitConfirmListTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getPendingToSubmitConfirmListTest.java
@@ -1,0 +1,50 @@
+package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDaoTest;
+
+import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 05/02/16.
+ */
+public class getPendingToSubmitConfirmListTest {
+    @Mock
+    private PluginDatabaseSystem mockPluginDatabaseSystem;
+    @Mock
+    private Database mockDatabase;
+    @Mock
+    DatabaseTable databaseTable;
+    private UUID testId;
+    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDao;
+    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDaoSpy;
+
+
+    @Before
+    public void setup()throws Exception{
+        testId = UUID.randomUUID();
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase);
+        customerOnlinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOnlinePaymentBusinessTransactionDao);
+        MockitoAnnotations.initMocks(this);
+        PowerMockito.doReturn(databaseTable).when(customerOnlinePaymentBusinessTransactionDaoSpy, "getDatabaseContractTable");
+    }
+    @Test
+    public void getPendingToSubmitConfirmListTest_Should_Return_Not_Null()throws Exception{
+        assertNotNull(customerOnlinePaymentBusinessTransactionDaoSpy.getPendingToSubmitConfirmList());
+    }
+    @Test(expected = Exception.class)
+    public void getPendingToSubmitConfirmListTest_Should_Throw_Exception()throws Exception{
+        customerOnlinePaymentBusinessTransactionDao.getPendingToSubmitConfirmList();
+    }
+}

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getPendingToSubmitCryptoListTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getPendingToSubmitCryptoListTest.java
@@ -1,0 +1,53 @@
+package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDaoTest;
+
+import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 05/02/16.
+ */
+public class getPendingToSubmitCryptoListTest {
+    @Mock
+    private PluginDatabaseSystem mockPluginDatabaseSystem;
+    @Mock
+    private Database mockDatabase;
+    @Mock
+    DatabaseTable databaseTable;
+    private UUID testId;
+    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDao;
+    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDaoSpy;
+
+
+    @Before
+    public void setup()throws Exception{
+        testId = UUID.randomUUID();
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase);
+        customerOnlinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOnlinePaymentBusinessTransactionDao);
+        MockitoAnnotations.initMocks(this);
+        PowerMockito.doReturn(databaseTable).when(customerOnlinePaymentBusinessTransactionDaoSpy, "getDatabaseContractTable");
+    }
+    @Test
+    public void getPendingToSubmitCryptoListTestTest_Should()throws Exception{
+
+        assertNotNull(customerOnlinePaymentBusinessTransactionDaoSpy.getPendingToSubmitCryptoList());
+    }
+    @Test(expected = Exception.class)
+    public void getPendingToSubmitCryptoListTestTest()throws Exception{
+        customerOnlinePaymentBusinessTransactionDao.getPendingToSubmitCryptoList();
+    }
+
+}

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getPendingToSubmitNotificationListTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getPendingToSubmitNotificationListTest.java
@@ -1,0 +1,49 @@
+package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDaoTest;
+
+import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 05/02/16.
+ */
+public class getPendingToSubmitNotificationListTest {
+    @Mock
+    private PluginDatabaseSystem mockPluginDatabaseSystem;
+    @Mock
+    private Database mockDatabase;
+    @Mock
+    DatabaseTable databaseTable;
+    private UUID testId;
+    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDao;
+    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDaoSpy;
+
+
+    @Before
+    public void setup()throws Exception{
+        testId = UUID.randomUUID();
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase);
+        customerOnlinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOnlinePaymentBusinessTransactionDao);
+        MockitoAnnotations.initMocks(this);
+        PowerMockito.doReturn(databaseTable).when(customerOnlinePaymentBusinessTransactionDaoSpy, "getDatabaseContractTable");
+    }
+    @Test
+    public void getPendingToSubmitNotificationListTest_Should_Return_Not_Null()throws Exception{
+        assertNotNull(customerOnlinePaymentBusinessTransactionDaoSpy.getPendingToSubmitNotificationList());
+    }
+    @Test(expected = Exception.class)
+    public void getPendingToSubmitNotificationListTest_Should_Throw_Exception()throws Exception{
+        customerOnlinePaymentBusinessTransactionDao.getPendingToSubmitNotificationList();
+    }
+}

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/exceptions/CantInitializeCustomerOnlinePaymentBusinessTransactionDatabaseExceptionTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/exceptions/CantInitializeCustomerOnlinePaymentBusinessTransactionDatabaseExceptionTest.java
@@ -1,0 +1,46 @@
+package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.exceptions;
+
+import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseFilterType;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDatabaseConstants;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.exceptions.CantInitializeCustomerOnlinePaymentBusinessTransactionDatabaseException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+
+import java.util.UUID;
+
+/**
+ * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 04/02/16.
+ */
+public class CantInitializeCustomerOnlinePaymentBusinessTransactionDatabaseExceptionTest {
+    @Mock
+    private PluginDatabaseSystem mockPluginDatabaseSystem;
+
+    private Database mockDatabase;
+    @Mock
+    private DatabaseTable databaseTable;
+    private UUID testId;
+    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDao;
+    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDaoSpy;
+
+    @Before
+    public void setup()throws Exception{
+        testId = UUID.randomUUID();
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase);
+        customerOnlinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOnlinePaymentBusinessTransactionDao);
+        MockitoAnnotations.initMocks(this);
+        PowerMockito.doReturn(databaseTable).when(customerOnlinePaymentBusinessTransactionDaoSpy, "getDatabaseContractTable");
+    }
+    @Test(expected = CantInitializeCustomerOnlinePaymentBusinessTransactionDatabaseException.class)
+    public void CustomerOnlinePaymentBusinessTransactionDaoInitTest()throws Exception{
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(null,null,mockDatabase);
+        customerOnlinePaymentBusinessTransactionDao.initialize();
+    }
+}

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/structure/CustomerOnlinePaymentMonitorAgentTest/startTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/structure/CustomerOnlinePaymentMonitorAgentTest/startTest.java
@@ -70,10 +70,21 @@ public class startTest {
 
     @Test
     public void testStart() throws Exception {
+        customerOnlinePaymentMonitorAgent.setEventManager(eventManager);
+        customerOnlinePaymentMonitorAgent.setErrorManager(errorManager);
+        customerOnlinePaymentMonitorAgent.setPluginDatabaseSystem(pluginDatabaseSystem);
+        customerOnlinePaymentMonitorAgent.setLogManager(logManager);
+        customerOnlinePaymentMonitorAgent.setPluginId(pluginId);
         customerOnlinePaymentMonitorAgent.start();
 
-    }
 
+    }
+    @Test
+    public void testStop() throws Exception {
+        customerOnlinePaymentMonitorAgent.start();
+        customerOnlinePaymentMonitorAgent.stop();
+
+    }
     @Test(expected = Exception.class)
     public void testStart_Should_Return_Exception() throws Exception {
         customerOnlinePaymentMonitorAgent = new CustomerOnlinePaymentMonitorAgent(null,null,null,null,null,null,null,null,null);

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/structure/CustomerOnlinePaymentTransactionManagerTest/parseToLongTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/structure/CustomerOnlinePaymentTransactionManagerTest/parseToLongTest.java
@@ -1,0 +1,42 @@
+package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.structure.CustomerOnlinePaymentTransactionManagerTest;
+
+import com.bitdubai.fermat_api.layer.all_definition.exceptions.InvalidParameterException;
+import com.bitdubai.fermat_cbp_api.layer.contract.customer_broker_purchase.interfaces.CustomerBrokerContractPurchaseManager;
+import com.bitdubai.fermat_cbp_api.layer.negotiation.customer_broker_purchase.interfaces.CustomerBrokerPurchaseNegotiationManager;
+import com.bitdubai.fermat_cbp_api.layer.network_service.transaction_transmission.interfaces.TransactionTransmissionManager;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.structure.CustomerOnlinePaymentTransactionManager;
+
+import org.junit.Test;
+import org.mockito.Mock;
+
+/**
+ * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 04/02/16.
+ */
+public class parseToLongTest {
+    @Mock
+    CustomerBrokerContractPurchaseManager customerBrokerContractPurchaseManager;
+    @Mock
+    CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDao;
+    @Mock
+    TransactionTransmissionManager transactionTransmissionManager;
+    @Mock
+    CustomerBrokerPurchaseNegotiationManager customerBrokerPurchaseNegotiationManager;
+    CustomerOnlinePaymentTransactionManager customerOnlinePaymentTransactionManager;
+
+    @Test
+    public void parseToLongTest_Should_Return_Long()throws Exception{
+        customerOnlinePaymentTransactionManager = new CustomerOnlinePaymentTransactionManager(customerBrokerContractPurchaseManager,customerOnlinePaymentBusinessTransactionDao,transactionTransmissionManager,customerBrokerPurchaseNegotiationManager);
+        customerOnlinePaymentTransactionManager.parseToLong("1");
+    }
+    @Test(expected = InvalidParameterException.class)
+    public void parseToLongTest_Should_Return_null_InvalidParameterException()throws Exception{
+        customerOnlinePaymentTransactionManager = new CustomerOnlinePaymentTransactionManager(customerBrokerContractPurchaseManager,customerOnlinePaymentBusinessTransactionDao,transactionTransmissionManager,customerBrokerPurchaseNegotiationManager);
+        customerOnlinePaymentTransactionManager.parseToLong(null);
+    }
+    @Test(expected = InvalidParameterException.class)
+    public void parseToLongTest_Should_Return_long_InvalidParameterException()throws Exception{
+        customerOnlinePaymentTransactionManager = new CustomerOnlinePaymentTransactionManager(customerBrokerContractPurchaseManager,customerOnlinePaymentBusinessTransactionDao,transactionTransmissionManager,customerBrokerPurchaseNegotiationManager);
+        customerOnlinePaymentTransactionManager.parseToLong("A");
+    }
+}


### PR DESCRIPTION
#4516
New updates/fixes to the following:

1)CustomerOnlinePaymentBusinessTransactionDao has seen changes to support for another methodunit testing

New Test:
1)CustomerOnlinePaymentBusinessTransactionDao.getOnCryptoNetworkCryptoStatusListTest
2)CustomerOnlinePaymentBusinessTransactionDao,getPendingEventsTest
3)CustomerOnlinePaymentBusinessTransactionDao,getPendingToSubmitConfirmListTest
4)CustomerOnlinePaymentBusinessTransactionDao.getPendingToSubmitCryptoListTest
5)CustomerOnlinePaymentBusinessTransactionDao.getPendingToSubmitNotificationsListTest
6)CantInitializeCustomerOnlinePaymentBusinessTransactionDatabaseExceptionTest
7)CustomerOnlinePaymentTransactionManagerTest.parseToLongTest
