### PR TITLE
Develop

### DIFF
--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDao.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDao.java
@@ -129,12 +129,7 @@ public class CustomerOfflinePaymentBusinessTransactionDao {
      *
      * @return DatabaseTable
      */
-    /**
-     * Access modifier was changed from private to protected to enhance
-     * testability
-     */
-    // private
-    protected DatabaseTable getDatabaseContractTable() {
+    private DatabaseTable getDatabaseContractTable() {
         return getDataBase().getTable(
                 CustomerOfflinePaymentBusinessTransactionDatabaseConstants.OFFLINE_PAYMENT_TABLE_NAME);
     }
@@ -144,12 +139,7 @@ public class CustomerOfflinePaymentBusinessTransactionDao {
      *
      * @return DatabaseTable
      */
-    /**
-     * Access modifier was changed from private to protected to enhance
-     * testability
-     */
-    // private
-    protected DatabaseTable getDatabaseEventsTable() {
+    private DatabaseTable getDatabaseEventsTable() {
         return getDataBase().getTable(
                 CustomerOfflinePaymentBusinessTransactionDatabaseConstants.OFFLINE_PAYMENT_EVENTS_RECORDED_TABLE_NAME);
     }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDaoTest/getContractTransactionStatusTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDaoTest/getContractTransactionStatusTest.java
@@ -2,8 +2,11 @@ package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offli
 
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTableRecord;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDatabaseConstants;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 import org.junit.Before;
@@ -11,13 +14,14 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
 
 import java.security.InvalidParameterException;
+import java.util.List;
 import java.util.UUID;
 
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 01/02/16.
@@ -31,26 +35,31 @@ public class getContractTransactionStatusTest {
     DatabaseTable databaseTable;
     @Mock
     ErrorManager errorManager;
+    @Mock
+    List<DatabaseTableRecord> databaseTableRecordList;
+    @Mock
+    DatabaseTableRecord databaseTableRecord;
     private UUID testId;
     private CustomerOfflinePaymentBusinessTransactionDao customerOfflinePaymentBusinessTransactionDao;
-    private CustomerOfflinePaymentBusinessTransactionDao customerOfflinePaymentBusinessTransactionDaoSpy;
     @Before
     public void setup() throws Exception{
         testId = UUID.randomUUID();
-        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
-        customerOfflinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOfflinePaymentBusinessTransactionDao);
         MockitoAnnotations.initMocks(this);
-        PowerMockito.doReturn(databaseTable).when(customerOfflinePaymentBusinessTransactionDaoSpy, "getDatabaseContractTable");
+        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
+        when(mockDatabase.getTable(CustomerOfflinePaymentBusinessTransactionDatabaseConstants.OFFLINE_PAYMENT_TABLE_NAME)).thenReturn(databaseTable);
+        when(databaseTable.getRecords()).thenReturn(databaseTableRecordList);
     }
 
-    /*@Test
+    @Test
     public void getContractTransactionStatusTest_Should_Run_Once() throws Exception{
-        customerOfflinePaymentBusinessTransactionDaoSpy.getContractTransactionStatus(""+hashCode()+"");
-    }*/
+        when(databaseTableRecordList.get(0)).thenReturn(databaseTableRecord);
+        when(databaseTableRecord.getStringValue(CustomerOfflinePaymentBusinessTransactionDatabaseConstants.OFFLINE_PAYMENT_CONTRACT_TRANSACTION_STATUS_COLUMN_NAME)).thenReturn("AFM");
+        customerOfflinePaymentBusinessTransactionDao.getContractTransactionStatus("Test");
+    }
 
-    @Test(expected = Exception.class)
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
     public void getContractTransactionStatusTest_Should_Return_Exception() throws Exception{
-        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(null,null,null,null);
+        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(null,null,null,errorManager);
         customerOfflinePaymentBusinessTransactionDao.getContractTransactionStatus(null);
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDaoTest/getCustomerOfflinePaymentRecordTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDaoTest/getCustomerOfflinePaymentRecordTest.java
@@ -1,6 +1,14 @@
 package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDaoTest;
 
+import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseFilterType;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTableRecord;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDatabaseConstants;
+import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -9,27 +17,66 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 
+import java.util.List;
+import java.util.UUID;
+
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 01/02/16.
  */
 public class getCustomerOfflinePaymentRecordTest {
     private CustomerOfflinePaymentBusinessTransactionDao customerOfflinePaymentBusinessTransactionDao;
+    @Mock
+    private PluginDatabaseSystem mockPluginDatabaseSystem;
+    @Mock
+    private Database mockDatabase;
+    @Mock
+    DatabaseTable databaseTable;
+    @Mock
+    ErrorManager errorManager;
+    @Mock
+    List<DatabaseTableRecord> databaseTableRecordList;
+    @Mock
+    DatabaseTableRecord databaseTableRecord;
+    private UUID testId;
     @Before
-    public void setup(){
+    public void setup()throws Exception{
+        testId = UUID.randomUUID();
         MockitoAnnotations.initMocks(this);
+        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
+        when(mockDatabase.getTable(CustomerOfflinePaymentBusinessTransactionDatabaseConstants.OFFLINE_PAYMENT_TABLE_NAME)).thenReturn(databaseTable);
+        doNothing().when(databaseTable).addStringFilter(
+                CustomerOfflinePaymentBusinessTransactionDatabaseConstants.OFFLINE_PAYMENT_CONTRACT_HASH_COLUMN_NAME,
+                "Test",
+                DatabaseFilterType.EQUAL);
+        doNothing().when(databaseTable).loadToMemory();
+        when(databaseTable.getRecords()).thenReturn(databaseTableRecordList);
+        when(databaseTableRecordList.get(0)).thenReturn(databaseTableRecord);
+        when(databaseTableRecord.getStringValue(CustomerOfflinePaymentBusinessTransactionDatabaseConstants.
+                OFFLINE_PAYMENT_BROKER_PUBLIC_KEY_COLUMN_NAME)).thenReturn("contract_transaction_status");
+        when(databaseTableRecord.getStringValue(
+                CustomerOfflinePaymentBusinessTransactionDatabaseConstants.
+                        OFFLINE_PAYMENT_CONTRACT_HASH_COLUMN_NAME)).thenReturn("contract_hash");
     }
-    /*@Test
+    @Test
     public void getCustomerOfflinePaymentRecord_Should_Run_Once() throws Exception{
-        customerOfflinePaymentBusinessTransactionDao.getCustomerOfflinePaymentRecord(anyString());
-        //verify(customerOfflinePaymentBusinessTransactionDao,Mockito.times(1)).getCustomerOfflinePaymentRecord(anyString());
-    }*/
-
-    @Test(expected = Exception.class)
+        when(databaseTableRecord.getStringValue(
+                CustomerOfflinePaymentBusinessTransactionDatabaseConstants.
+                        OFFLINE_PAYMENT_CONTRACT_TRANSACTION_STATUS_COLUMN_NAME)).thenReturn("POMC");
+        customerOfflinePaymentBusinessTransactionDao.getCustomerOfflinePaymentRecord("Test");
+    }
+    //InvalidParameterException
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
+    public void getCustomerOfflinePaymentRecord_Should_Throw_Exception() throws Exception{
+        customerOfflinePaymentBusinessTransactionDao.getCustomerOfflinePaymentRecord("Test");
+    }
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
     public void getCustomerOfflinePaymentRecord_Should_Return_Exception() throws Exception{
-        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(null,null,null,null);
+        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(null,null,null,errorManager);
         customerOfflinePaymentBusinessTransactionDao.getCustomerOfflinePaymentRecord(null);
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDaoTest/getPendingCryptoTransactionListTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDaoTest/getPendingCryptoTransactionListTest.java
@@ -3,7 +3,9 @@ package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offli
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDatabaseConstants;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 
@@ -14,11 +16,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.UUID;
 
-
-import org.powermock.api.mockito.PowerMockito;
-
-import static org.junit.Assert.assertNotNull;
-
+import static org.mockito.Mockito.when;
 
 
 /**
@@ -36,20 +34,23 @@ public class getPendingCryptoTransactionListTest {
     ErrorManager errorManager;
     private UUID testId;
     private CustomerOfflinePaymentBusinessTransactionDao customerOfflinePaymentBusinessTransactionDao;
-    private CustomerOfflinePaymentBusinessTransactionDao customerOfflinePaymentBusinessTransactionDaoSpy;
 
 
     @Before
     public void setup()throws Exception{
         testId = UUID.randomUUID();
-        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
-        customerOfflinePaymentBusinessTransactionDaoSpy = PowerMockito.spy( customerOfflinePaymentBusinessTransactionDao);
         MockitoAnnotations.initMocks(this);
-        PowerMockito.doReturn(databaseTable).when(customerOfflinePaymentBusinessTransactionDaoSpy, "getDatabaseContractTable");
+        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
     }
 
     @Test
     public void getPendingCryptoTransactionListTest_Should_()throws Exception{
-        customerOfflinePaymentBusinessTransactionDaoSpy.getPendingCryptoTransactionList();
+        when(mockDatabase.getTable(CustomerOfflinePaymentBusinessTransactionDatabaseConstants.OFFLINE_PAYMENT_TABLE_NAME)).thenReturn(databaseTable);
+        customerOfflinePaymentBusinessTransactionDao.getPendingCryptoTransactionList();
+    }
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
+    public void getPendingCryptoTransactionListTest_Should_Throw_Exception()throws Exception{
+        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(null,testId,mockDatabase,errorManager);
+        customerOfflinePaymentBusinessTransactionDao.getPendingCryptoTransactionList();
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDaoTest/getPendingEventsTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDaoTest/getPendingEventsTest.java
@@ -3,16 +3,19 @@ package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offli
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDatabaseConstants;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
 
 import java.util.UUID;
+
+import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 05/02/16.
@@ -28,20 +31,23 @@ public class getPendingEventsTest {
     DatabaseTable databaseTable;
     private UUID testId;
     private CustomerOfflinePaymentBusinessTransactionDao customerOfflinePaymentBusinessTransactionDao;
-    private CustomerOfflinePaymentBusinessTransactionDao customerOfflinePaymentBusinessTransactionDaoSpy;
 
 
     @Before
     public void setup()throws Exception{
         testId = UUID.randomUUID();
-        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
-        customerOfflinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOfflinePaymentBusinessTransactionDao);
         MockitoAnnotations.initMocks(this);
-        PowerMockito.doReturn(databaseTable).when(customerOfflinePaymentBusinessTransactionDaoSpy, "getDatabaseEventsTable");
+        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
     }
 
     @Test
     public void getPendingEventsTest_Should_Return_Empty_List() throws Exception{
-        customerOfflinePaymentBusinessTransactionDaoSpy.getPendingEvents();
+        when(mockDatabase.getTable(CustomerOfflinePaymentBusinessTransactionDatabaseConstants.OFFLINE_PAYMENT_EVENTS_RECORDED_TABLE_NAME)).thenReturn(databaseTable);
+        customerOfflinePaymentBusinessTransactionDao.getPendingEvents();
+    }
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
+    public void getPendingEventsTest_Should_Throw_Exception() throws Exception{
+        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(null,testId,mockDatabase,errorManager);
+        customerOfflinePaymentBusinessTransactionDao.getPendingEvents();
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDaoTest/getPendingToSubmitConfirmListTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDaoTest/getPendingToSubmitConfirmListTest.java
@@ -3,19 +3,21 @@ package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offli
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDatabaseConstants;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
 
 import java.util.UUID;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 05/02/16.
@@ -31,19 +33,22 @@ public class getPendingToSubmitConfirmListTest {
     ErrorManager errorManager;
     private UUID testId;
     private CustomerOfflinePaymentBusinessTransactionDao customerOfflinePaymentBusinessTransactionDao;
-    private CustomerOfflinePaymentBusinessTransactionDao customerOfflinePaymentBusinessTransactionDaoSpy;
 
 
     @Before
     public void setup()throws Exception{
         testId = UUID.randomUUID();
-        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
-        customerOfflinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOfflinePaymentBusinessTransactionDao);
         MockitoAnnotations.initMocks(this);
-        PowerMockito.doReturn(databaseTable).when(customerOfflinePaymentBusinessTransactionDaoSpy, "getDatabaseContractTable");
+        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
     }
     @Test
     public void getPendingToSubmitConfirmListTest_Should_Return_Not_Null()throws Exception{
-        assertNotNull(customerOfflinePaymentBusinessTransactionDaoSpy.getPendingToSubmitConfirmList());
+        when(mockDatabase.getTable(CustomerOfflinePaymentBusinessTransactionDatabaseConstants.OFFLINE_PAYMENT_TABLE_NAME)).thenReturn(databaseTable);
+        assertNotNull(customerOfflinePaymentBusinessTransactionDao.getPendingToSubmitConfirmList());
+    }
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
+    public void getPendingToSubmitConfirmListTest_Should_Throw_Exception()throws Exception{
+        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(null,testId,mockDatabase,errorManager);
+        customerOfflinePaymentBusinessTransactionDao.getPendingToSubmitConfirmList();
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDaoTest/getPendingToSubmitNotificationListTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDaoTest/getPendingToSubmitNotificationListTest.java
@@ -3,18 +3,20 @@ package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offli
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDatabaseConstants;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
 
 import java.util.UUID;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 05/02/16.
@@ -30,19 +32,22 @@ public class getPendingToSubmitNotificationListTest {
     ErrorManager errorManager;
     private UUID testId;
     private CustomerOfflinePaymentBusinessTransactionDao customerOfflinePaymentBusinessTransactionDao;
-    private CustomerOfflinePaymentBusinessTransactionDao customerOfflinePaymentBusinessTransactionDaoSpy;
 
 
     @Before
     public void setup()throws Exception{
         testId = UUID.randomUUID();
-        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
-        customerOfflinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOfflinePaymentBusinessTransactionDao);
         MockitoAnnotations.initMocks(this);
-        PowerMockito.doReturn(databaseTable).when(customerOfflinePaymentBusinessTransactionDaoSpy, "getDatabaseContractTable");
+        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
     }
     @Test
     public void getPendingToSubmitNotificationListTest_Should_Return_Not_Null()throws Exception{
-        assertNotNull(customerOfflinePaymentBusinessTransactionDaoSpy.getPendingToSubmitNotificationList());
+        when(mockDatabase.getTable(CustomerOfflinePaymentBusinessTransactionDatabaseConstants.OFFLINE_PAYMENT_TABLE_NAME)).thenReturn(databaseTable);
+        assertNotNull(customerOfflinePaymentBusinessTransactionDao.getPendingToSubmitNotificationList());
+    }
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
+    public void getPendingToSubmitNotificationListTest_Should_Throw_Exception()throws Exception{
+        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(null,testId,mockDatabase,errorManager);
+        customerOfflinePaymentBusinessTransactionDao.getPendingToSubmitNotificationList();
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDaoTest/initializeTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDaoTest/initializeTest.java
@@ -4,6 +4,7 @@ import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseFactory;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.exceptions.CantInitializeCustomerOfflinePaymentBusinessTransactionDatabaseException;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 import org.junit.Test;
@@ -38,7 +39,7 @@ public class initializeTest {
         customerOfflinePaymentBusinessTransactionDao.initialize();
     }
 
-    @Test(expected = Exception.class)
+    @Test(expected = CantInitializeCustomerOfflinePaymentBusinessTransactionDatabaseException.class)
     public void TestCreateDatabase_Should_Return_Exception() throws Exception{
         customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(null,testId,mockDatabase,errorManager);
         customerOfflinePaymentBusinessTransactionDao.initialize();

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDaoTest/isContractHashInDatabaseTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDaoTest/isContractHashInDatabaseTest.java
@@ -3,16 +3,19 @@ package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offli
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDatabaseConstants;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
 
 import java.util.UUID;
+
+import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 03/02/16.
@@ -28,21 +31,23 @@ public class isContractHashInDatabaseTest {
     ErrorManager errorManager;
     private UUID testId;
     private CustomerOfflinePaymentBusinessTransactionDao customerOfflinePaymentBusinessTransactionDao;
-    private CustomerOfflinePaymentBusinessTransactionDao customerOfflinePaymentBusinessTransactionDaoSpy;
 
 
     @Before
     public void setup()throws Exception{
         testId = UUID.randomUUID();
-        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
-        customerOfflinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOfflinePaymentBusinessTransactionDao);
         MockitoAnnotations.initMocks(this);
-        PowerMockito.doReturn(databaseTable).when(customerOfflinePaymentBusinessTransactionDaoSpy, "getDatabaseContractTable");
+        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
+        when(mockDatabase.getTable(CustomerOfflinePaymentBusinessTransactionDatabaseConstants.OFFLINE_PAYMENT_TABLE_NAME)).thenReturn(databaseTable);
     }
 
     @Test
     public void isContractHashInDatabaseTest_Should_()throws Exception{
-        customerOfflinePaymentBusinessTransactionDaoSpy.isContractHashInDatabase("65ef1c685c7a5502eef44a5f8552801d9cb4ca87");
+        customerOfflinePaymentBusinessTransactionDao.isContractHashInDatabase("65ef1c685c7a5502eef44a5f8552801d9cb4ca87");
     }
-
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
+    public void isContractHashInDatabaseTest_Should_Throw_Exception()throws Exception{
+        customerOfflinePaymentBusinessTransactionDao = new CustomerOfflinePaymentBusinessTransactionDao(null,null,null,errorManager);
+        customerOfflinePaymentBusinessTransactionDao.isContractHashInDatabase(null);
+    }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDatabaseFactoryTest/DatabaseTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/database/CustomerOfflinePaymentBusinessTransactionDatabaseFactoryTest/DatabaseTest.java
@@ -68,9 +68,4 @@ public class DatabaseTest {
         Database checkDatabase = customerOfflinePaymentBusinessTransactionDatabaseFactory.createDatabase(testId, testDataBaseName);
         assertNotNull(checkDatabase);
     }
-    @Test(expected = Exception.class)
-    public void TestCreateDatabase_Should_Return_Exception() throws Exception{
-        customerOfflinePaymentBusinessTransactionDatabaseFactory = new CustomerOfflinePaymentBusinessTransactionDatabaseFactory(null);
-        customerOfflinePaymentBusinessTransactionDatabaseFactory.createDatabase(null, null);
-    }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/event_handler/CustomerOfflinePaymentRecorderServiceTest/incomingConfirmBusinessTransactionResponseTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/event_handler/CustomerOfflinePaymentRecorderServiceTest/incomingConfirmBusinessTransactionResponseTest.java
@@ -1,11 +1,12 @@
 package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.event_handler.CustomerOfflinePaymentRecorderServiceTest;
 
 import com.bitdubai.fermat_api.layer.all_definition.enums.Plugins;
+import com.bitdubai.fermat_api.layer.all_definition.enums.interfaces.FermatEventEnum;
+import com.bitdubai.fermat_api.layer.all_definition.events.EventSource;
 import com.bitdubai.fermat_api.layer.all_definition.events.interfaces.FermatEventListener;
 import com.bitdubai.fermat_cbp_api.all_definition.events.enums.EventType;
 import com.bitdubai.fermat_cbp_api.all_definition.exceptions.CantSaveEventException;
 import com.bitdubai.fermat_cbp_api.layer.network_service.transaction_transmission.events.IncomingConfirmBusinessTransactionResponse;
-import com.bitdubai.fermat_cbp_api.layer.network_service.transaction_transmission.events.IncomingNewContractStatusUpdate;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDao;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.event_handler.CustomerOfflinePaymentRecorderService;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
@@ -16,6 +17,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 /**
@@ -30,14 +32,19 @@ public class incomingConfirmBusinessTransactionResponseTest {
     ErrorManager errorManager;
     @Mock
     FermatEventListener mockFermatEventListener;
-    IncomingConfirmBusinessTransactionResponse incomingConfirmBusinessTransactionResponse;
+    @Mock
+    IncomingConfirmBusinessTransactionResponse mockIncomingConfirmBusinessTransactionResponse;
+    @Mock
+    FermatEventEnum fermatEventEnum;
+    EventSource eventSource = EventSource.ACTOR_ASSET_ISSUER;
     CustomerOfflinePaymentRecorderService customerOfflinePaymentRecorderService;
 
     public void setUpGeneralMockitoRules() throws Exception{
-        when(eventManager.getNewListener(EventType.INCOMING_NEW_CONTRACT_STATUS_UPDATE)).thenReturn(mockFermatEventListener);
-        when(eventManager.getNewListener(EventType.INCOMING_CONFIRM_BUSINESS_TRANSACTION_RESPONSE)).thenReturn(mockFermatEventListener);
-
-
+        when(mockIncomingConfirmBusinessTransactionResponse.getRemoteBusinessTransaction()).thenReturn(Plugins.CUSTOMER_OFFLINE_PAYMENT);
+        when(mockIncomingConfirmBusinessTransactionResponse.getSource()).thenReturn(eventSource);
+        doNothing().when(customerOfflinePaymentBusinessTransactionDao).saveNewEvent(
+                "1",
+                eventSource.getCode());
     }
     @Before
     public void setup()throws Exception{
@@ -46,24 +53,16 @@ public class incomingConfirmBusinessTransactionResponseTest {
     }
     @Test
     public void incomingConfirmBusinessTransactionResponseTest_Should_Return_() throws Exception {
-        //when(incomingConfirmBusinessTransactionResponse.getRemoteBusinessTransaction()).thenReturn(Plugins.CUSTOMER_OFFLINE_PAYMENT);
+        when(mockIncomingConfirmBusinessTransactionResponse.getEventType()).thenReturn(fermatEventEnum);
+        when(fermatEventEnum.getCode()).thenReturn("1");
         customerOfflinePaymentRecorderService = new CustomerOfflinePaymentRecorderService(customerOfflinePaymentBusinessTransactionDao,eventManager,errorManager);
-        //customerOfflinePaymentRecorderService.incomingConfirmBusinessTransactionResponse(incomingConfirmBusinessTransactionResponse);
-    }
+        customerOfflinePaymentRecorderService.incomingConfirmBusinessTransactionResponse(mockIncomingConfirmBusinessTransactionResponse);
 
-    @Test(expected = Exception.class)
-    public void incomingConfirmBusinessTransactionResponseTest_Should_Throw_Exception() throws Exception {
-        customerOfflinePaymentRecorderService = new CustomerOfflinePaymentRecorderService(customerOfflinePaymentBusinessTransactionDao,eventManager,errorManager);
-        customerOfflinePaymentRecorderService.setEventManager(eventManager);
-        customerOfflinePaymentRecorderService.start();
-        customerOfflinePaymentRecorderService.incomingConfirmBusinessTransactionResponse(null);
     }
 
     @Test(expected = CantSaveEventException.class)
-    public void incomingConfirmBusinessTransactionResponseTest_Should_Throw_CantSaveEventException() throws Exception {
+    public void incomingConfirmBusinessTransactionResponseTest_Should_Throw_Exception() throws Exception {
         customerOfflinePaymentRecorderService = new CustomerOfflinePaymentRecorderService(customerOfflinePaymentBusinessTransactionDao,eventManager,errorManager);
-        customerOfflinePaymentRecorderService.setEventManager(eventManager);
-        customerOfflinePaymentRecorderService.start();
-        customerOfflinePaymentRecorderService.incomingConfirmBusinessTransactionResponse(incomingConfirmBusinessTransactionResponse);
+        customerOfflinePaymentRecorderService.incomingConfirmBusinessTransactionResponse(mockIncomingConfirmBusinessTransactionResponse);
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/event_handler/CustomerOfflinePaymentRecorderServiceTest/incomingNewContractStatusUpdateEventHandlerTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/event_handler/CustomerOfflinePaymentRecorderServiceTest/incomingNewContractStatusUpdateEventHandlerTest.java
@@ -1,6 +1,8 @@
 package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.event_handler.CustomerOfflinePaymentRecorderServiceTest;
 
 import com.bitdubai.fermat_api.layer.all_definition.enums.Plugins;
+import com.bitdubai.fermat_api.layer.all_definition.enums.interfaces.FermatEventEnum;
+import com.bitdubai.fermat_api.layer.all_definition.events.EventSource;
 import com.bitdubai.fermat_api.layer.all_definition.events.interfaces.FermatEventListener;
 import com.bitdubai.fermat_cbp_api.all_definition.events.enums.EventType;
 import com.bitdubai.fermat_cbp_api.all_definition.exceptions.CantSaveEventException;
@@ -15,7 +17,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 /**
@@ -30,13 +32,17 @@ public class incomingNewContractStatusUpdateEventHandlerTest {
     ErrorManager errorManager;
     @Mock
     FermatEventListener mockFermatEventListener;
-    IncomingNewContractStatusUpdate incomingNewContractStatusUpdate;
+
+    IncomingNewContractStatusUpdate incomingNewContractStatusUpdate = new IncomingNewContractStatusUpdate(EventType.CUSTOMER_OFFLINE_PAYMENT_CONFIRMED);
     CustomerOfflinePaymentRecorderService customerOfflinePaymentRecorderService;
+    @Mock
+    FermatEventEnum fermatEventEnum;
+    EventSource eventSource = EventSource.ACTOR_ASSET_ISSUER;
 
     public void setUpGeneralMockitoRules() throws Exception{
-        when(eventManager.getNewListener(EventType.INCOMING_NEW_CONTRACT_STATUS_UPDATE)).thenReturn(mockFermatEventListener);
-        when(eventManager.getNewListener(EventType.INCOMING_CONFIRM_BUSINESS_TRANSACTION_RESPONSE)).thenReturn(mockFermatEventListener);
-
+        doNothing().when(customerOfflinePaymentBusinessTransactionDao).saveNewEvent(
+                EventType.CUSTOMER_OFFLINE_PAYMENT_CONFIRMED.getCode(),
+                eventSource.getCode());
 
     }
     @Before
@@ -44,27 +50,11 @@ public class incomingNewContractStatusUpdateEventHandlerTest {
         MockitoAnnotations.initMocks(this);
         setUpGeneralMockitoRules();
     }
-    /*
     @Test
     public void incomingNewContractStatusUpdateEventHandlerTest_Should_Return_() throws Exception {
-        when(incomingNewContractStatusUpdate.getRemoteBusinessTransaction()).thenReturn(Plugins.CUSTOMER_OFFLINE_PAYMENT);
+        incomingNewContractStatusUpdate.setRemoteBusinessTransaction(Plugins.CUSTOMER_OFFLINE_PAYMENT);
+        incomingNewContractStatusUpdate.setSource(eventSource);
         customerOfflinePaymentRecorderService = new CustomerOfflinePaymentRecorderService(customerOfflinePaymentBusinessTransactionDao,eventManager,errorManager);
-        //customerOfflinePaymentRecorderService.incomingNewContractStatusUpdateEventHandler(incomingNewContractStatusUpdate);
-    }*/
-
-    @Test(expected = Exception.class)
-    public void incomingNewContractStatusUpdateEventHandlerTest_Should_Throw_Exception() throws Exception {
-        customerOfflinePaymentRecorderService = new CustomerOfflinePaymentRecorderService(customerOfflinePaymentBusinessTransactionDao,eventManager,errorManager);
-        customerOfflinePaymentRecorderService.setEventManager(eventManager);
-        customerOfflinePaymentRecorderService.start();
-        customerOfflinePaymentRecorderService.incomingNewContractStatusUpdateEventHandler(null);
-    }
-
-    @Test(expected = CantSaveEventException.class)
-    public void incomingNewContractStatusUpdateEventHandlerTest_Should_Throw_CantSaveEventException() throws Exception {
-        customerOfflinePaymentRecorderService = new CustomerOfflinePaymentRecorderService(customerOfflinePaymentBusinessTransactionDao,eventManager,errorManager);
-        customerOfflinePaymentRecorderService.setEventManager(eventManager);
-        customerOfflinePaymentRecorderService.start();
         customerOfflinePaymentRecorderService.incomingNewContractStatusUpdateEventHandler(incomingNewContractStatusUpdate);
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/event_handler/CustomerOfflinePaymentRecorderServiceTest/testStart.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/event_handler/CustomerOfflinePaymentRecorderServiceTest/testStart.java
@@ -3,6 +3,7 @@ package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offli
 import com.bitdubai.fermat_api.layer.all_definition.enums.ServiceStatus;
 import com.bitdubai.fermat_api.layer.all_definition.events.interfaces.FermatEventListener;
 import com.bitdubai.fermat_cbp_api.all_definition.events.enums.EventType;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.CantStartServiceException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDao;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.event_handler.CustomerOfflinePaymentRecorderService;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
@@ -52,9 +53,9 @@ public class testStart {
         assertEquals(ServiceStatus.STARTED, customerOfflinePaymentRecorderService.getStatus());
     }
 
-    @Test(expected = Exception.class)
+    @Test(expected = CantStartServiceException.class)
     public void testStart_Should_Return_Exception() throws Exception {
-        customerOfflinePaymentRecorderService = new CustomerOfflinePaymentRecorderService(null,null,null);
+        customerOfflinePaymentRecorderService = new CustomerOfflinePaymentRecorderService(null,null,errorManager);
         customerOfflinePaymentRecorderService.start();
     }
 

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/exceptions/CantInitializeCustomerOfflinePaymentBusinessTransactionDatabaseExceptionTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/exceptions/CantInitializeCustomerOfflinePaymentBusinessTransactionDatabaseExceptionTest.java
@@ -1,20 +1,11 @@
 package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.exceptions;
 
-import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
-import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseFilterType;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
-import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDao;
-import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDatabaseConstants;
-import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.exceptions.CantInitializeCustomerOfflinePaymentBusinessTransactionDatabaseException;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
 
-import java.util.UUID;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 04/02/16.

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/structure/CustomerOfflinePaymentMonitorAgentTest/startTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/structure/CustomerOfflinePaymentMonitorAgentTest/startTest.java
@@ -85,9 +85,4 @@ public class startTest {
         customerOfflinePaymentMonitorAgent.stop();
 
     }
-    @Test(expected = Exception.class)
-    public void testStart_Should_Return_Exception() throws Exception {
-        customerOfflinePaymentMonitorAgent = new CustomerOfflinePaymentMonitorAgent(null,null,null,null,null,null,null,null);
-        customerOfflinePaymentMonitorAgent.start();
-    }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/structure/CustomerOfflinePaymentTransactionManagerTest/getContractTransactionStatusTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/structure/CustomerOfflinePaymentTransactionManagerTest/getContractTransactionStatusTest.java
@@ -1,7 +1,10 @@
 package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.structure.CustomerOfflinePaymentTransactionManagerTest;
 
 import com.bitdubai.fermat_cbp_api.all_definition.enums.ContractTransactionStatus;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_api.layer.contract.customer_broker_purchase.interfaces.CustomerBrokerContractPurchaseManager;
+import com.bitdubai.fermat_cbp_api.layer.negotiation.customer_broker_purchase.interfaces.CustomerBrokerPurchaseNegotiationManager;
+import com.bitdubai.fermat_cbp_api.layer.network_service.transaction_transmission.interfaces.TransactionTransmissionManager;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDao;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.structure.CustomerOfflinePaymentTransactionManager;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
@@ -26,7 +29,10 @@ public class getContractTransactionStatusTest {
     CustomerOfflinePaymentBusinessTransactionDao customerOfflinePaymentBusinessTransactionDao;
     @Mock
     ErrorManager errorManager;
-
+    @Mock
+    TransactionTransmissionManager transactionTransmissionManager;
+    @Mock
+    CustomerBrokerPurchaseNegotiationManager customerBrokerPurchaseNegotiationManager;
     @Before
     public void setup() throws Exception{
         MockitoAnnotations.initMocks(this);
@@ -38,12 +44,20 @@ public class getContractTransactionStatusTest {
         customerOfflinePaymentTransactionManager = new CustomerOfflinePaymentTransactionManager(customerBrokerContractPurchaseManager,
                 customerOfflinePaymentBusinessTransactionDao,
                 errorManager);
-        assertNotNull(customerOfflinePaymentTransactionManager.getContractTransactionStatus(""));
+        assertNotNull(customerOfflinePaymentTransactionManager.getContractTransactionStatus("Test"));
     }
 
-    @Test(expected = Exception.class)
-    public void getContractTransactionStatusTest_Should_Throw_Exception() throws Exception{
-        customerOfflinePaymentTransactionManager = new CustomerOfflinePaymentTransactionManager(null,null,null);
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
+    public void getContractTransactionStatusTest_Should_Throw_UnexpectedResultReturnedFromDatabaseException() throws Exception{
+        customerOfflinePaymentTransactionManager = new CustomerOfflinePaymentTransactionManager(customerBrokerContractPurchaseManager,
+                customerOfflinePaymentBusinessTransactionDao,
+                errorManager);
         customerOfflinePaymentTransactionManager.getContractTransactionStatus(null);
+    }
+
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
+    public void getContractTransactionStatusTest_Should_Throw_Generic_UnexpectedResultReturnedFromDatabaseException() throws Exception{
+        customerOfflinePaymentTransactionManager = new CustomerOfflinePaymentTransactionManager(null,null,errorManager);
+        customerOfflinePaymentTransactionManager.getContractTransactionStatus("Test");
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/structure/CustomerOfflinePaymentTransactionManagerTest/sendPaymentTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_offline_payment/developer/bitdubai/version_1/structure/CustomerOfflinePaymentTransactionManagerTest/sendPaymentTest.java
@@ -1,7 +1,11 @@
 package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.structure.CustomerOfflinePaymentTransactionManagerTest;
 
 import com.bitdubai.fermat_cbp_api.layer.business_transaction.common.exceptions.CantSendPaymentException;
+import com.bitdubai.fermat_cbp_api.layer.business_transaction.common.mocks.PurchaseNegotiationOnlineMock;
+import com.bitdubai.fermat_cbp_api.layer.contract.customer_broker_purchase.interfaces.CustomerBrokerContractPurchase;
 import com.bitdubai.fermat_cbp_api.layer.contract.customer_broker_purchase.interfaces.CustomerBrokerContractPurchaseManager;
+import com.bitdubai.fermat_cbp_api.layer.negotiation.customer_broker_purchase.interfaces.CustomerBrokerPurchaseNegotiationManager;
+import com.bitdubai.fermat_cbp_api.layer.network_service.transaction_transmission.interfaces.TransactionTransmissionManager;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.database.CustomerOfflinePaymentBusinessTransactionDao;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_offline_payment.developer.bitdubai.version_1.structure.CustomerOfflinePaymentTransactionManager;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
@@ -10,6 +14,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import java.util.UUID;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 16/02/16.
@@ -22,31 +31,53 @@ public class sendPaymentTest {
     CustomerOfflinePaymentBusinessTransactionDao customerOfflinePaymentBusinessTransactionDao;
     @Mock
     ErrorManager errorManager;
+    @Mock
+    TransactionTransmissionManager transactionTransmissionManager;
+    @Mock
+    CustomerBrokerPurchaseNegotiationManager customerBrokerPurchaseNegotiationManager;
+    @Mock
+    CustomerBrokerContractPurchase customerBrokerContractPurchase;
+    PurchaseNegotiationOnlineMock purchaseNegotiationOnlineMock = new PurchaseNegotiationOnlineMock();
+    //@Mock
+    //Collection<Clause> collection;
+
+    //@Mock
+    //Iterator<Clause> iterator;
 
     @Before
     public void setup() throws Exception{
         MockitoAnnotations.initMocks(this);
+        customerOfflinePaymentTransactionManager = new CustomerOfflinePaymentTransactionManager(customerBrokerContractPurchaseManager,
+                customerOfflinePaymentBusinessTransactionDao,
+                errorManager);
+        setUpGeneralMockitoRules();
+    }
+    public void setUpGeneralMockitoRules() throws Exception{
+        when(customerBrokerContractPurchaseManager.getCustomerBrokerContractPurchaseForContractId(anyString())).thenReturn(customerBrokerContractPurchase);
+        when(customerBrokerContractPurchase.getNegotiatiotId()).thenReturn("00000000-0000-0000-C000-000000000046");
+        UUID negotiationUUID=UUID.fromString("00000000-0000-0000-C000-000000000046");
+        when(customerBrokerPurchaseNegotiationManager.getNegotiationsByNegotiationId(negotiationUUID)).thenReturn(purchaseNegotiationOnlineMock);
+
+
     }
 
     @Test
     public void sendPaymentTest_Should() throws Exception{
-        customerOfflinePaymentTransactionManager = new CustomerOfflinePaymentTransactionManager(customerBrokerContractPurchaseManager,
-                customerOfflinePaymentBusinessTransactionDao,
-                errorManager);
-        customerOfflinePaymentTransactionManager.sendPayment("");
+        customerOfflinePaymentTransactionManager.sendPayment("contractHash");
     }
 
+    //ObjectNotSetException
+    @Test(expected = CantSendPaymentException.class)
+    public void sendPaymentTest_Should_() throws Exception{
+
+        customerOfflinePaymentTransactionManager.sendPayment(null);
+    }
+    //Generic Exception
     @Test(expected = CantSendPaymentException.class)
     public void sendPaymentTest_Should_Throw_CantSendPaymentException() throws Exception{
         customerOfflinePaymentTransactionManager = new CustomerOfflinePaymentTransactionManager(null,
                 customerOfflinePaymentBusinessTransactionDao,
                 errorManager);
         customerOfflinePaymentTransactionManager.sendPayment("");
-    }
-
-    @Test(expected = Exception.class)
-    public void sendPaymentTest_Should_Throw_Exception() throws Exception{
-        customerOfflinePaymentTransactionManager = new CustomerOfflinePaymentTransactionManager(null,null,null);
-        customerOfflinePaymentTransactionManager.sendPayment(null);
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/build.gradle
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/build.gradle
@@ -15,8 +15,8 @@ dependencies {
     compile project(':fermat-cbp-api')
     compile project(':fermat-ccp-api')
     testCompile "junit:junit:4.11"
-    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.9.5'
-    testCompile "org.powermock:powermock-mockito-release-full:1.6.1"
+    testCompile 'org.mockito:mockito-all:2.0.2-beta'
+
 }
 
 

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/CustomerOnlinePaymentPluginRoot.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/CustomerOnlinePaymentPluginRoot.java
@@ -237,7 +237,8 @@ public class CustomerOnlinePaymentPluginRoot extends AbstractPlugin implements
                     this.customerBrokerContractPurchaseManager,
                     customerOnlinePaymentBusinessTransactionDao,
                     this.transactionTransmissionManager,
-                    this.customerBrokerPurchaseNegotiationManager);
+                    this.customerBrokerPurchaseNegotiationManager,
+                    this.errorManager);
 
             /**
              * Init event recorder service.

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDao.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDao.java
@@ -134,12 +134,8 @@ public class CustomerOnlinePaymentBusinessTransactionDao {
      *
      * @return DatabaseTable
      */
-    /**
-     * Access modifier was changed from private to protected to enhance
-     * testability
-     */
-    // private
-    protected DatabaseTable getDatabaseContractTable() {
+
+    private DatabaseTable getDatabaseContractTable() {
 
         return getDataBase().getTable(
                 CustomerOnlinePaymentBusinessTransactionDatabaseConstants.ONLINE_PAYMENT_TABLE_NAME);
@@ -150,12 +146,7 @@ public class CustomerOnlinePaymentBusinessTransactionDao {
      *
      * @return DatabaseTable
      */
-    /**
-     * Access modifier was changed from private to protected to enhance
-     * testability
-     */
-    // private
-    protected DatabaseTable getDatabaseEventsTable() {
+    private DatabaseTable getDatabaseEventsTable() {
         return getDataBase().getTable(
                 CustomerOnlinePaymentBusinessTransactionDatabaseConstants.ONLINE_PAYMENT_EVENTS_RECORDED_TABLE_NAME);
     }
@@ -483,8 +474,17 @@ public class CustomerOnlinePaymentBusinessTransactionDao {
             );
             return customerOnlinePaymentRecordList;
         } catch (CantGetContractListException exception) {
-            throw new CantGetContractListException(CantCreateDatabaseException.DEFAULT_MESSAGE, exception, "Getting value from getPendingCryptoTransactionList", "");
+            errorManager.reportUnexpectedPluginException(
+                    Plugins.CUSTOMER_ONLINE_PAYMENT,
+                    UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN,
+                    exception);
+            throw new CantGetContractListException(CantCreateDatabaseException.DEFAULT_MESSAGE, exception,
+                    "Getting value from getPendingCryptoTransactionList", "");
         } catch (Exception exception) {
+            errorManager.reportUnexpectedPluginException(
+                    Plugins.CUSTOMER_ONLINE_PAYMENT,
+                    UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN,
+                    exception);
             throw new UnexpectedResultReturnedFromDatabaseException(exception,
                     "Unexpected error",
                     "Check the cause");

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/structure/CustomerOnlinePaymentTransactionManager.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/structure/CustomerOnlinePaymentTransactionManager.java
@@ -64,11 +64,13 @@ public class CustomerOnlinePaymentTransactionManager implements CustomerOnlinePa
             CustomerBrokerContractPurchaseManager customerBrokerContractPurchaseManager,
             CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDao,
             TransactionTransmissionManager transactionTransmissionManager,
-            CustomerBrokerPurchaseNegotiationManager customerBrokerPurchaseNegotiationManager){
+            CustomerBrokerPurchaseNegotiationManager customerBrokerPurchaseNegotiationManager,
+            ErrorManager errorManager){
         this.customerBrokerContractPurchaseManager=customerBrokerContractPurchaseManager;
         this.customerOnlinePaymentBusinessTransactionDao=customerOnlinePaymentBusinessTransactionDao;
         this.transactionTransmissionManager=transactionTransmissionManager;
         this.customerBrokerPurchaseNegotiationManager=customerBrokerPurchaseNegotiationManager;
+        this.errorManager = errorManager;
     }
 
     /**
@@ -98,6 +100,7 @@ public class CustomerOnlinePaymentTransactionManager implements CustomerOnlinePa
         try{
 
             Collection<Clause> negotiationClauses=customerBrokerPurchaseNegotiation.getClauses();
+
             for(Clause clause : negotiationClauses){
                 if(clause.getType().equals(ClauseType.BROKER_CRYPTO_ADDRESS)){
                     return clause.getValue();
@@ -217,7 +220,7 @@ public class CustomerOnlinePaymentTransactionManager implements CustomerOnlinePa
         } catch (CantGetListCustomerBrokerContractPurchaseException e) {
             errorManager.reportUnexpectedPluginException(
                     Plugins.CUSTOMER_ONLINE_PAYMENT,
-                    UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN,
+                    UnexpectedPluginExceptionSeverity.DISABLES_THIS_PLUGIN,
                     e);
             throw new CantSendPaymentException(
                     e,
@@ -226,7 +229,7 @@ public class CustomerOnlinePaymentTransactionManager implements CustomerOnlinePa
         } catch (CantInsertRecordException e) {
             errorManager.reportUnexpectedPluginException(
                     Plugins.CUSTOMER_ONLINE_PAYMENT,
-                    UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN,
+                    UnexpectedPluginExceptionSeverity.DISABLES_THIS_PLUGIN,
                     e);
             throw new CantSendPaymentException(
                     e,
@@ -235,7 +238,7 @@ public class CustomerOnlinePaymentTransactionManager implements CustomerOnlinePa
         } catch (CantGetCryptoAddressException e) {
             errorManager.reportUnexpectedPluginException(
                     Plugins.CUSTOMER_ONLINE_PAYMENT,
-                    UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN,
+                    UnexpectedPluginExceptionSeverity.DISABLES_THIS_PLUGIN,
                     e);
             throw new CantSendPaymentException(
                     e,
@@ -244,7 +247,7 @@ public class CustomerOnlinePaymentTransactionManager implements CustomerOnlinePa
         } catch (CantGetListPurchaseNegotiationsException e) {
             errorManager.reportUnexpectedPluginException(
                     Plugins.CUSTOMER_ONLINE_PAYMENT,
-                    UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN,
+                    UnexpectedPluginExceptionSeverity.DISABLES_THIS_PLUGIN,
                     e);
             throw new CantSendPaymentException(
                     e,
@@ -253,7 +256,7 @@ public class CustomerOnlinePaymentTransactionManager implements CustomerOnlinePa
         } catch (CantGetCryptoAmountException e) {
             errorManager.reportUnexpectedPluginException(
                     Plugins.CUSTOMER_ONLINE_PAYMENT,
-                    UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN,
+                    UnexpectedPluginExceptionSeverity.DISABLES_THIS_PLUGIN,
                     e);
             throw new CantSendPaymentException(
                     e,
@@ -262,7 +265,7 @@ public class CustomerOnlinePaymentTransactionManager implements CustomerOnlinePa
         } catch (ObjectNotSetException e) {
             errorManager.reportUnexpectedPluginException(
                     Plugins.CUSTOMER_ONLINE_PAYMENT,
-                    UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN,
+                    UnexpectedPluginExceptionSeverity.DISABLES_THIS_PLUGIN,
                     e);
             throw new CantSendPaymentException(
                     e,
@@ -271,7 +274,7 @@ public class CustomerOnlinePaymentTransactionManager implements CustomerOnlinePa
         }catch (Exception e){
             errorManager.reportUnexpectedPluginException(
                     Plugins.CUSTOMER_ONLINE_PAYMENT,
-                    UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN,
+                    UnexpectedPluginExceptionSeverity.DISABLES_THIS_PLUGIN,
                     e);
             throw new CantSendPaymentException(e,
                     "Sending online payment",

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getContractTransactionStatusTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getContractTransactionStatusTest.java
@@ -1,9 +1,16 @@
 package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDaoTest;
 
+import com.bitdubai.fermat_api.layer.all_definition.enums.interfaces.FermatEnum;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseRecord;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTableRecord;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_api.all_definition.enums.ContractTransactionStatus;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDatabaseConstants;
+import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -11,10 +18,12 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 01/02/16.
@@ -27,22 +36,33 @@ public class getContractTransactionStatusTest {
     private Database mockDatabase;
     @Mock
     DatabaseTable databaseTable;
+    @Mock
+    ErrorManager errorManager;
+    @Mock
+    List<DatabaseTableRecord> databaseTableRecordList;
+    @Mock
+    DatabaseTableRecord databaseTableRecord;
     private UUID testId;
     @Before
-    public void setup(){
+    public void setup() throws Exception{
+        testId = UUID.randomUUID();
         MockitoAnnotations.initMocks(this);
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
+        when(mockDatabase.getTable(CustomerOnlinePaymentBusinessTransactionDatabaseConstants.ONLINE_PAYMENT_TABLE_NAME)).thenReturn(databaseTable);
+        when(databaseTable.getRecords()).thenReturn(databaseTableRecordList);
+
     }
 
-    /*@Test
+    @Test
     public void getContractTransactionStatusTest_Should_Run_Once() throws Exception{
-        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId,mockDatabase);
-        customerOnlinePaymentBusinessTransactionDao.getContractTransactionStatus(anyString());
-        verify(customerOnlinePaymentBusinessTransactionDao, Mockito.times(1)).getContractTransactionStatus(anyString());
-    }*/
+        when(databaseTableRecordList.get(0)).thenReturn(databaseTableRecord);
+        when(databaseTableRecord.getStringValue(CustomerOnlinePaymentBusinessTransactionDatabaseConstants.ONLINE_PAYMENT_CONTRACT_TRANSACTION_STATUS_COLUMN_NAME)).thenReturn("AFM");
+        customerOnlinePaymentBusinessTransactionDao.getContractTransactionStatus("Test");
+    }
 
-    @Test(expected = Exception.class)
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
     public void getContractTransactionStatusTest_Should_Return_Exception() throws Exception{
-        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(null,null,null,null);
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId,mockDatabase,errorManager);
         customerOnlinePaymentBusinessTransactionDao.getContractTransactionStatus(null);
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getCustomerOnlinePaymentRecordTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getCustomerOnlinePaymentRecordTest.java
@@ -1,6 +1,15 @@
 package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDaoTest;
 
+import com.bitdubai.fermat_api.layer.all_definition.exceptions.InvalidParameterException;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseFilterType;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTableRecord;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDatabaseConstants;
+import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -9,27 +18,72 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 
+import java.util.List;
+import java.util.UUID;
+
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 01/02/16.
  */
 public class getCustomerOnlinePaymentRecordTest {
     private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDao;
-    @Before
-    public void setup(){
-        MockitoAnnotations.initMocks(this);
-    }
-    /*@Test
-    public void getCustomerOnlinePaymentRecord_Should_Run_Once() throws Exception{
-        customerOnlinePaymentBusinessTransactionDao.getCustomerOnlinePaymentRecord(anyString());
-        verify(customerOnlinePaymentBusinessTransactionDao,Mockito.times(1)).getCustomerOnlinePaymentRecord(anyString());
-    }*/
 
-    @Test(expected = Exception.class)
-    public void getCustomerOnlinePaymentRecord_Should_Return_Exception() throws Exception{
-        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(null,null,null,null);
+    @Mock
+    private PluginDatabaseSystem mockPluginDatabaseSystem;
+    @Mock
+    private Database mockDatabase;
+    @Mock
+    DatabaseTable databaseTable;
+    @Mock
+    ErrorManager errorManager;
+    @Mock
+    List<DatabaseTableRecord> databaseTableRecordList;
+    @Mock
+    DatabaseTableRecord databaseTableRecord;
+    private UUID testId;
+
+    @Before
+    public void setup()throws Exception{
+        testId = UUID.randomUUID();
+        MockitoAnnotations.initMocks(this);
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
+        when(mockDatabase.getTable(CustomerOnlinePaymentBusinessTransactionDatabaseConstants.ONLINE_PAYMENT_TABLE_NAME)).thenReturn(databaseTable);
+        doNothing().when(databaseTable).addStringFilter(
+                CustomerOnlinePaymentBusinessTransactionDatabaseConstants.ONLINE_PAYMENT_CONTRACT_HASH_COLUMN_NAME,
+                "Test",
+                DatabaseFilterType.EQUAL);
+        doNothing().when(databaseTable).loadToMemory();
+        when(databaseTable.getRecords()).thenReturn(databaseTableRecordList);
+        when(databaseTableRecordList.get(0)).thenReturn(databaseTableRecord);
+        when(databaseTableRecord.getStringValue(CustomerOnlinePaymentBusinessTransactionDatabaseConstants.
+                ONLINE_PAYMENT_BROKER_PUBLIC_KEY_COLUMN_NAME)).thenReturn("contract_transaction_status");
+        when(databaseTableRecord.getStringValue(
+                CustomerOnlinePaymentBusinessTransactionDatabaseConstants.
+                        ONLINE_PAYMENT_CONTRACT_HASH_COLUMN_NAME)).thenReturn("contract_hash");
+
+    }
+    //InvalidParameterException
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
+    public void getCustomerOnlinePaymentRecord_Should_Throw_Exception() throws Exception{
+        customerOnlinePaymentBusinessTransactionDao.getCustomerOnlinePaymentRecord("Test");
+    }
+
+    @Test
+    public void getCustomerOnlinePaymentRecord_Should_() throws Exception{
+
+        when(databaseTableRecord.getStringValue(
+                CustomerOnlinePaymentBusinessTransactionDatabaseConstants.
+                        ONLINE_PAYMENT_CONTRACT_TRANSACTION_STATUS_COLUMN_NAME)).thenReturn("POMC");
+        customerOnlinePaymentBusinessTransactionDao.getCustomerOnlinePaymentRecord("Test");
+    }
+    //Generic Exception
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
+    public void getCustomerOnlinePaymentRecord_Should_Throw_Generic_Exception() throws Exception{
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(null,null,null,errorManager);
         customerOnlinePaymentBusinessTransactionDao.getCustomerOnlinePaymentRecord(null);
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getOnBlockchainkCryptoStatusListTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getOnBlockchainkCryptoStatusListTest.java
@@ -3,18 +3,20 @@ package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_onlin
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDatabaseConstants;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
 
 import java.util.UUID;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 03/02/16.
@@ -31,24 +33,23 @@ public class getOnBlockchainkCryptoStatusListTest {
     ErrorManager errorManager;
     private UUID testId;
     private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDao;
-    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDaoSpy;
 
 
     @Before
     public void setup()throws Exception{
         testId = UUID.randomUUID();
-        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
-        customerOnlinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOnlinePaymentBusinessTransactionDao);
         MockitoAnnotations.initMocks(this);
-        PowerMockito.doReturn(databaseTable).when(customerOnlinePaymentBusinessTransactionDaoSpy, "getDatabaseContractTable");
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
+
     }
     @Test
     public void getOnBlockchainkCryptoStatusListTest_Should()throws Exception{
-        assertNotNull(customerOnlinePaymentBusinessTransactionDaoSpy.getOnBlockchainkCryptoStatusList());
+        when(mockDatabase.getTable(CustomerOnlinePaymentBusinessTransactionDatabaseConstants.ONLINE_PAYMENT_TABLE_NAME)).thenReturn(databaseTable);
+        customerOnlinePaymentBusinessTransactionDao.getOnBlockchainkCryptoStatusList();
     }
-    @Test(expected = Exception.class)
+    //Generic Exception
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
     public void getOnBlockchainkCryptoStatusListTest_()throws Exception{
-        testId = UUID.randomUUID();
         customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId,mockDatabase,errorManager);
         customerOnlinePaymentBusinessTransactionDao.getOnBlockchainkCryptoStatusList();
     }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getOnCryptoNetworkCryptoStatusListTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getOnCryptoNetworkCryptoStatusListTest.java
@@ -3,18 +3,20 @@ package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_onlin
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDatabaseConstants;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
 
 import java.util.UUID;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 05/02/16.
@@ -30,23 +32,23 @@ public class getOnCryptoNetworkCryptoStatusListTest {
     ErrorManager errorManager;
     private UUID testId;
     private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDao;
-    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDaoSpy;
 
 
     @Before
     public void setup()throws Exception{
         testId = UUID.randomUUID();
-        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
-        customerOnlinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOnlinePaymentBusinessTransactionDao);
         MockitoAnnotations.initMocks(this);
-        PowerMockito.doReturn(databaseTable).when(customerOnlinePaymentBusinessTransactionDaoSpy, "getDatabaseContractTable");
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
     }
     @Test
     public void getOnCryptoNetworkCryptoStatusListTest_Should_Return_Not_Null()throws Exception{
-        assertNotNull(customerOnlinePaymentBusinessTransactionDaoSpy.getOnCryptoNetworkCryptoStatusList());
+        when(mockDatabase.getTable(CustomerOnlinePaymentBusinessTransactionDatabaseConstants.ONLINE_PAYMENT_TABLE_NAME)).thenReturn(databaseTable);
+        assertNotNull(customerOnlinePaymentBusinessTransactionDao.getOnCryptoNetworkCryptoStatusList());
     }
-    @Test(expected = Exception.class)
+    //Generic Exception
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
     public void getOnCryptoNetworkCryptoStatusListTest_Should_Throw_Exception()throws Exception{
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(null,testId,mockDatabase,errorManager);
         customerOnlinePaymentBusinessTransactionDao.getOnCryptoNetworkCryptoStatusList();
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getPendingCryptoTransactionListTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getPendingCryptoTransactionListTest.java
@@ -3,7 +3,9 @@ package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_onlin
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDatabaseConstants;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 
@@ -14,11 +16,8 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.UUID;
 
-
-import org.powermock.api.mockito.PowerMockito;
-
 import static org.junit.Assert.assertNotNull;
-
+import static org.mockito.Mockito.when;
 
 
 /**
@@ -36,25 +35,23 @@ public class getPendingCryptoTransactionListTest {
     ErrorManager errorManager;
     private UUID testId;
     private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDao;
-    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDaoSpy;
 
 
     @Before
     public void setup()throws Exception{
         testId = UUID.randomUUID();
-        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
-        customerOnlinePaymentBusinessTransactionDaoSpy = PowerMockito.spy( customerOnlinePaymentBusinessTransactionDao);
         MockitoAnnotations.initMocks(this);
-        PowerMockito.doReturn(databaseTable).when(customerOnlinePaymentBusinessTransactionDaoSpy, "getDatabaseContractTable");
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
     }
 
     @Test
     public void getPendingCryptoTransactionListTest_Should_()throws Exception{
-        assertNotNull(customerOnlinePaymentBusinessTransactionDaoSpy.getPendingCryptoTransactionList());
+        when(mockDatabase.getTable(CustomerOnlinePaymentBusinessTransactionDatabaseConstants.ONLINE_PAYMENT_TABLE_NAME)).thenReturn(databaseTable);
+        assertNotNull(customerOnlinePaymentBusinessTransactionDao.getPendingCryptoTransactionList());
     }
-    @Test(expected = Exception.class)
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
     public void getPendingCryptoTransactionListTest_Should_Throw_Exception()throws Exception{
-        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(null,null,null,null);
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(null,testId,mockDatabase,errorManager);
         customerOnlinePaymentBusinessTransactionDao.getPendingCryptoTransactionList();
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getPendingEventsTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getPendingEventsTest.java
@@ -3,16 +3,19 @@ package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_onlin
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDatabaseConstants;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
 
 import java.util.UUID;
+
+import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 05/02/16.
@@ -28,24 +31,24 @@ public class getPendingEventsTest {
     ErrorManager errorManager;
     private UUID testId;
     private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDao;
-    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDaoSpy;
 
 
     @Before
     public void setup()throws Exception{
         testId = UUID.randomUUID();
-        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
-        customerOnlinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOnlinePaymentBusinessTransactionDao);
         MockitoAnnotations.initMocks(this);
-        PowerMockito.doReturn(databaseTable).when(customerOnlinePaymentBusinessTransactionDaoSpy, "getDatabaseEventsTable");
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
     }
 
     @Test
     public void getPendingEventsTest_Should_Return_Empty_List() throws Exception{
-        customerOnlinePaymentBusinessTransactionDaoSpy.getPendingEvents();
+        when(mockDatabase.getTable(CustomerOnlinePaymentBusinessTransactionDatabaseConstants.ONLINE_PAYMENT_EVENTS_RECORDED_TABLE_NAME)).thenReturn(databaseTable);
+        customerOnlinePaymentBusinessTransactionDao.getPendingEvents();
     }
-    @Test(expected = Exception.class)
+    //Generic Exception
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
     public void getPendingEventsTest_Should_Throw_Exception() throws Exception{
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(null,testId,mockDatabase,errorManager);
         customerOnlinePaymentBusinessTransactionDao.getPendingEvents();
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getPendingToSubmitConfirmListTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getPendingToSubmitConfirmListTest.java
@@ -3,19 +3,21 @@ package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_onlin
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDatabaseConstants;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
 
 import java.util.UUID;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 05/02/16.
@@ -31,23 +33,23 @@ public class getPendingToSubmitConfirmListTest {
     ErrorManager errorManager;
     private UUID testId;
     private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDao;
-    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDaoSpy;
 
 
     @Before
     public void setup()throws Exception{
         testId = UUID.randomUUID();
-        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
-        customerOnlinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOnlinePaymentBusinessTransactionDao);
         MockitoAnnotations.initMocks(this);
-        PowerMockito.doReturn(databaseTable).when(customerOnlinePaymentBusinessTransactionDaoSpy, "getDatabaseContractTable");
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
     }
     @Test
     public void getPendingToSubmitConfirmListTest_Should_Return_Not_Null()throws Exception{
-        assertNotNull(customerOnlinePaymentBusinessTransactionDaoSpy.getPendingToSubmitConfirmList());
+        when(mockDatabase.getTable(CustomerOnlinePaymentBusinessTransactionDatabaseConstants.ONLINE_PAYMENT_TABLE_NAME)).thenReturn(databaseTable);
+        assertNotNull(customerOnlinePaymentBusinessTransactionDao.getPendingToSubmitConfirmList());
     }
-    @Test(expected = Exception.class)
+    //Generic Exception
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
     public void getPendingToSubmitConfirmListTest_Should_Throw_Exception()throws Exception{
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(null,testId,mockDatabase,errorManager);
         customerOnlinePaymentBusinessTransactionDao.getPendingToSubmitConfirmList();
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getPendingToSubmitCryptoListTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getPendingToSubmitCryptoListTest.java
@@ -3,20 +3,22 @@ package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_onlin
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDatabaseConstants;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
 
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 05/02/16.
@@ -32,24 +34,23 @@ public class getPendingToSubmitCryptoListTest {
     ErrorManager errorManager;
     private UUID testId;
     private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDao;
-    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDaoSpy;
 
 
     @Before
     public void setup()throws Exception{
         testId = UUID.randomUUID();
-        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
-        customerOnlinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOnlinePaymentBusinessTransactionDao);
         MockitoAnnotations.initMocks(this);
-        PowerMockito.doReturn(databaseTable).when(customerOnlinePaymentBusinessTransactionDaoSpy, "getDatabaseContractTable");
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
     }
     @Test
     public void getPendingToSubmitCryptoListTestTest_Should()throws Exception{
-
-        assertNotNull(customerOnlinePaymentBusinessTransactionDaoSpy.getPendingToSubmitCryptoList());
+        when(mockDatabase.getTable(CustomerOnlinePaymentBusinessTransactionDatabaseConstants.ONLINE_PAYMENT_TABLE_NAME)).thenReturn(databaseTable);
+        assertNotNull(customerOnlinePaymentBusinessTransactionDao.getPendingToSubmitCryptoList());
     }
-    @Test(expected = Exception.class)
+    //Generic Exception
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
     public void getPendingToSubmitCryptoListTestTest()throws Exception{
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(null,testId,mockDatabase,errorManager);
         customerOnlinePaymentBusinessTransactionDao.getPendingToSubmitCryptoList();
     }
 

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getPendingToSubmitNotificationListTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/getPendingToSubmitNotificationListTest.java
@@ -3,18 +3,20 @@ package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_onlin
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDatabaseConstants;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
 
 import java.util.UUID;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 05/02/16.
@@ -30,23 +32,22 @@ public class getPendingToSubmitNotificationListTest {
     ErrorManager errorManager;
     private UUID testId;
     private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDao;
-    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDaoSpy;
 
 
     @Before
     public void setup()throws Exception{
         testId = UUID.randomUUID();
-        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
-        customerOnlinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOnlinePaymentBusinessTransactionDao);
         MockitoAnnotations.initMocks(this);
-        PowerMockito.doReturn(databaseTable).when(customerOnlinePaymentBusinessTransactionDaoSpy, "getDatabaseContractTable");
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
     }
     @Test
     public void getPendingToSubmitNotificationListTest_Should_Return_Not_Null()throws Exception{
-        assertNotNull(customerOnlinePaymentBusinessTransactionDaoSpy.getPendingToSubmitNotificationList());
+        when(mockDatabase.getTable(CustomerOnlinePaymentBusinessTransactionDatabaseConstants.ONLINE_PAYMENT_TABLE_NAME)).thenReturn(databaseTable);
+        assertNotNull(customerOnlinePaymentBusinessTransactionDao.getPendingToSubmitNotificationList());
     }
-    @Test(expected = Exception.class)
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
     public void getPendingToSubmitNotificationListTest_Should_Throw_Exception()throws Exception{
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(null,testId,mockDatabase,errorManager);
         customerOnlinePaymentBusinessTransactionDao.getPendingToSubmitNotificationList();
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/initializeTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/initializeTest.java
@@ -4,6 +4,7 @@ import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseFactory;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.exceptions.CantInitializeCustomerOnlinePaymentBusinessTransactionDatabaseException;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 import org.junit.Test;
@@ -38,9 +39,9 @@ public class initializeTest {
         customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId,mockDatabase,errorManager);
         customerOnlinePaymentBusinessTransactionDao.initialize();
     }
-
-    @Test(expected = Exception.class)
-    public void TestCreateDatabase_Should_Return_Exception() throws Exception{
+    //Generic Exception
+    @Test(expected = CantInitializeCustomerOnlinePaymentBusinessTransactionDatabaseException.class)
+    public void TestCreateDatabase_Should_Throw_Exception() throws Exception{
         customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(null,testId,mockDatabase,errorManager);
         customerOnlinePaymentBusinessTransactionDao.initialize();
     }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/isContractHashInDatabaseTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDaoTest/isContractHashInDatabaseTest.java
@@ -3,16 +3,19 @@ package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_onlin
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
+import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDatabaseConstants;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
 
 import java.util.UUID;
+
+import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 03/02/16.
@@ -28,24 +31,24 @@ public class isContractHashInDatabaseTest {
     ErrorManager errorManager;
     private UUID testId;
     private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDao;
-    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDaoSpy;
 
 
     @Before
     public void setup()throws Exception{
         testId = UUID.randomUUID();
-        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
-        customerOnlinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOnlinePaymentBusinessTransactionDao);
         MockitoAnnotations.initMocks(this);
-        PowerMockito.doReturn(databaseTable).when(customerOnlinePaymentBusinessTransactionDaoSpy, "getDatabaseContractTable");
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
     }
 
     @Test
     public void isContractHashInDatabaseTest_Should_()throws Exception{
-        customerOnlinePaymentBusinessTransactionDaoSpy.isContractHashInDatabase("65ef1c685c7a5502eef44a5f8552801d9cb4ca87");
+        when(mockDatabase.getTable(CustomerOnlinePaymentBusinessTransactionDatabaseConstants.ONLINE_PAYMENT_TABLE_NAME)).thenReturn(databaseTable);
+        customerOnlinePaymentBusinessTransactionDao.isContractHashInDatabase("65ef1c685c7a5502eef44a5f8552801d9cb4ca87");
     }
-    @Test(expected = Exception.class)
+    //Generic exception
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
     public void isContractHashInDatabaseTest_Should_Throw_Exception()throws Exception{
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(null,null,null,errorManager);
         customerOnlinePaymentBusinessTransactionDao.isContractHashInDatabase(null);
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDatabaseFactoryTest/DatabaseTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDatabaseFactoryTest/DatabaseTest.java
@@ -68,9 +68,4 @@ public class DatabaseTest {
         Database checkDatabase = customerOnlinePaymentBusinessTransactionDatabaseFactory.createDatabase(testId, testDataBaseName);
         assertNotNull(checkDatabase);
     }
-    @Test(expected = Exception.class)
-    public void TestCreateDatabase_Should_Return_Exception() throws Exception{
-        customerOnlinePaymentBusinessTransactionDatabaseFactory = new CustomerOnlinePaymentBusinessTransactionDatabaseFactory(null);
-        customerOnlinePaymentBusinessTransactionDatabaseFactory.createDatabase(null, null);
-    }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDeveloperDatabaseFactoryTest/initializeDatabaseTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/database/CustomerOnlinePaymentBusinessTransactionDeveloperDatabaseFactoryTest/initializeDatabaseTest.java
@@ -1,14 +1,8 @@
 package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDeveloperDatabaseFactoryTest;
 
-import com.bitdubai.fermat_api.layer.all_definition.developer.DeveloperObjectFactory;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
-import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseFactory;
-import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTableFactory;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
-import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDatabaseConstants;
-import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDatabaseFactory;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDeveloperDatabaseFactory;
-import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.exceptions.CantInitializeCustomerOnlinePaymentBusinessTransactionDatabaseException;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -17,11 +11,6 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.UUID;
-
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 03/02/16.
@@ -35,39 +24,19 @@ public class initializeDatabaseTest {
     @Mock
     private Database mockDatabase;
     private UUID testId;
-    private String testDataBaseName;
     private CustomerOnlinePaymentBusinessTransactionDeveloperDatabaseFactory customerOnlinePaymentBusinessTransactionDeveloperDatabaseFactory;
     public void setUpTestValues(){
         testId = UUID.randomUUID();
-        testDataBaseName = CustomerOnlinePaymentBusinessTransactionDatabaseConstants.DATABASE_NAME;
-    }
-
-    public void setUpGeneralMockitoRules() throws Exception{
-        when(mockPluginDatabaseSystem.createDatabase(testId, testDataBaseName)).thenReturn(mockDatabase);
-
     }
 
     @Before
     public void setUp() throws Exception{
         setUpTestValues();
-        setUpGeneralMockitoRules();
     }
-/*
+
     @Test
     public void TestInitializeDatabaseTest_Should_() throws Exception{
         customerOnlinePaymentBusinessTransactionDeveloperDatabaseFactory = new CustomerOnlinePaymentBusinessTransactionDeveloperDatabaseFactory(mockPluginDatabaseSystem,testId);
         customerOnlinePaymentBusinessTransactionDeveloperDatabaseFactory.initializeDatabase();
-        //FALTA CONFIRMACION!!!!!!!!!!!!!!
-
-    }*/
-    @Test(expected = Exception.class)
-    public void TestCreateDatabase_Should_Return_Exception() throws Exception{
-        customerOnlinePaymentBusinessTransactionDeveloperDatabaseFactory = new CustomerOnlinePaymentBusinessTransactionDeveloperDatabaseFactory(null,null);
-        customerOnlinePaymentBusinessTransactionDeveloperDatabaseFactory.initializeDatabase();
-    }/*
-    @Test(expected = CantInitializeCustomerOnlinePaymentBusinessTransactionDatabaseException.class )
-    public void TestCreateDatabase_Should_Return_() throws Exception{
-        customerOnlinePaymentBusinessTransactionDeveloperDatabaseFactory = new CustomerOnlinePaymentBusinessTransactionDeveloperDatabaseFactory(null,testId);
-        customerOnlinePaymentBusinessTransactionDeveloperDatabaseFactory.initializeDatabase();
-    }*/
+    }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/event_handler/CustomerOnlinePaymentRecorderServiceTest/incomingConfirmBussinessTransactionResponseTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/event_handler/CustomerOnlinePaymentRecorderServiceTest/incomingConfirmBussinessTransactionResponseTest.java
@@ -1,7 +1,9 @@
 package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.event_handler.CustomerOnlinePaymentRecorderServiceTest;
 
+import com.bitdubai.fermat_api.layer.all_definition.enums.Plugins;
+import com.bitdubai.fermat_api.layer.all_definition.enums.interfaces.FermatEventEnum;
+import com.bitdubai.fermat_api.layer.all_definition.events.EventSource;
 import com.bitdubai.fermat_api.layer.all_definition.events.interfaces.FermatEventListener;
-import com.bitdubai.fermat_cbp_api.all_definition.events.enums.EventType;
 import com.bitdubai.fermat_cbp_api.all_definition.exceptions.CantSaveEventException;
 import com.bitdubai.fermat_cbp_api.layer.network_service.transaction_transmission.events.IncomingConfirmBusinessTransactionResponse;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
@@ -14,6 +16,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 /**
@@ -28,40 +31,39 @@ public class incomingConfirmBussinessTransactionResponseTest {
     ErrorManager errorManager;
     @Mock
     FermatEventListener mockFermatEventListener;
-    IncomingConfirmBusinessTransactionResponse incomingConfirmBusinessTransactionResponse;
+    @Mock
+    IncomingConfirmBusinessTransactionResponse mockIncomingConfirmBusinessTransactionResponse;
+
     CustomerOnlinePaymentRecorderService customerOnlinePaymentRecorderService;
-
-    public void setUpGeneralMockitoRules() throws Exception{
-        when(eventManager.getNewListener(EventType.INCOMING_NEW_CONTRACT_STATUS_UPDATE)).thenReturn(mockFermatEventListener);
-        when(eventManager.getNewListener(EventType.INCOMING_CONFIRM_BUSINESS_TRANSACTION_RESPONSE)).thenReturn(mockFermatEventListener);
-
-
-    }
+    @Mock
+    FermatEventEnum fermatEventEnum;
+    EventSource eventSource = EventSource.ACTOR_ASSET_ISSUER;
     @Before
     public void setup()throws Exception{
         MockitoAnnotations.initMocks(this);
         setUpGeneralMockitoRules();
     }
-    /*@Test
+    public void setUpGeneralMockitoRules() throws Exception{
+        when(mockIncomingConfirmBusinessTransactionResponse.getRemoteBusinessTransaction()).thenReturn(Plugins.CUSTOMER_ONLINE_PAYMENT);
+        when(mockIncomingConfirmBusinessTransactionResponse.getSource()).thenReturn(eventSource);
+        doNothing().when(customerOnlinePaymentBusinessTransactionDao).saveNewEvent(
+                "1",
+                eventSource.getCode());
+
+    }
+    @Test
     public void incomingConfirmBusinessTransactionResponseTest_Should_Return_() throws Exception {
-        //when(incomingConfirmBusinessTransactionResponse.getRemoteBusinessTransaction()).thenReturn(Plugins.CUSTOMER_ONLINE_PAYMENT);
+        when(mockIncomingConfirmBusinessTransactionResponse.getEventType()).thenReturn(fermatEventEnum);
+        when(fermatEventEnum.getCode()).thenReturn("1");
         customerOnlinePaymentRecorderService = new CustomerOnlinePaymentRecorderService(customerOnlinePaymentBusinessTransactionDao,eventManager,errorManager);
-        //customerOnlinePaymentRecorderService.incomingConfirmBusinessTransactionResponse(incomingConfirmBusinessTransactionResponse);
-    }*/
-
-    @Test(expected = Exception.class)
-    public void incomingConfirmBusinessTransactionResponseTest_Should_Throw_Exception() throws Exception {
-        customerOnlinePaymentRecorderService = new CustomerOnlinePaymentRecorderService(customerOnlinePaymentBusinessTransactionDao,eventManager,errorManager);
-        customerOnlinePaymentRecorderService.setEventManager(eventManager);
-        customerOnlinePaymentRecorderService.start();
-        customerOnlinePaymentRecorderService.incomingConfirmBusinessTransactionResponse(null);
+        customerOnlinePaymentRecorderService.incomingConfirmBusinessTransactionResponse(mockIncomingConfirmBusinessTransactionResponse);
     }
-
+    //generic Exception
     @Test(expected = CantSaveEventException.class)
-    public void incomingConfirmBusinessTransactionResponseTest_Should_Throw_CantSaveEventException() throws Exception {
+    public void incomingConfirmBusinessTransactionResponseTest_Should_Throw_() throws Exception {
         customerOnlinePaymentRecorderService = new CustomerOnlinePaymentRecorderService(customerOnlinePaymentBusinessTransactionDao,eventManager,errorManager);
-        customerOnlinePaymentRecorderService.setEventManager(eventManager);
-        customerOnlinePaymentRecorderService.start();
-        customerOnlinePaymentRecorderService.incomingConfirmBusinessTransactionResponse(incomingConfirmBusinessTransactionResponse);
+        customerOnlinePaymentRecorderService.incomingConfirmBusinessTransactionResponse(mockIncomingConfirmBusinessTransactionResponse);
     }
+
+
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/event_handler/CustomerOnlinePaymentRecorderServiceTest/incomingNewContractStatusUpdateEventHandlerTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/event_handler/CustomerOnlinePaymentRecorderServiceTest/incomingNewContractStatusUpdateEventHandlerTest.java
@@ -1,8 +1,10 @@
 package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.event_handler.CustomerOnlinePaymentRecorderServiceTest;
 
+import com.bitdubai.fermat_api.layer.all_definition.enums.Plugins;
+import com.bitdubai.fermat_api.layer.all_definition.enums.interfaces.FermatEventEnum;
+import com.bitdubai.fermat_api.layer.all_definition.events.EventSource;
 import com.bitdubai.fermat_api.layer.all_definition.events.interfaces.FermatEventListener;
 import com.bitdubai.fermat_cbp_api.all_definition.events.enums.EventType;
-import com.bitdubai.fermat_cbp_api.all_definition.exceptions.CantSaveEventException;
 import com.bitdubai.fermat_cbp_api.layer.network_service.transaction_transmission.events.IncomingNewContractStatusUpdate;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.event_handler.CustomerOnlinePaymentRecorderService;
@@ -14,7 +16,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doNothing;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 18/02/16.
@@ -28,13 +30,17 @@ public class incomingNewContractStatusUpdateEventHandlerTest {
     ErrorManager errorManager;
     @Mock
     FermatEventListener mockFermatEventListener;
-    IncomingNewContractStatusUpdate incomingNewContractStatusUpdate;
+
+    IncomingNewContractStatusUpdate incomingNewContractStatusUpdate = new IncomingNewContractStatusUpdate(EventType.CUSTOMER_ONLINE_PAYMENT_CONFIRMED);
     CustomerOnlinePaymentRecorderService customerOnlinePaymentRecorderService;
+    @Mock
+    FermatEventEnum fermatEventEnum;
+    EventSource eventSource = EventSource.ACTOR_ASSET_ISSUER;
 
     public void setUpGeneralMockitoRules() throws Exception{
-        when(eventManager.getNewListener(EventType.INCOMING_NEW_CONTRACT_STATUS_UPDATE)).thenReturn(mockFermatEventListener);
-        when(eventManager.getNewListener(EventType.INCOMING_CONFIRM_BUSINESS_TRANSACTION_RESPONSE)).thenReturn(mockFermatEventListener);
-
+        doNothing().when(customerOnlinePaymentBusinessTransactionDao).saveNewEvent(
+                EventType.CUSTOMER_ONLINE_PAYMENT_CONFIRMED.getCode(),
+                eventSource.getCode());
 
     }
     @Before
@@ -42,26 +48,11 @@ public class incomingNewContractStatusUpdateEventHandlerTest {
         MockitoAnnotations.initMocks(this);
         setUpGeneralMockitoRules();
     }
-    /*@Test
+    @Test
     public void incomingNewContractStatusUpdateEventHandlerTest_Should_Return_() throws Exception {
-        when(incomingNewContractStatusUpdate.getRemoteBusinessTransaction()).thenReturn(Plugins.CUSTOMER_ONLINE_PAYMENT);
+        incomingNewContractStatusUpdate.setRemoteBusinessTransaction(Plugins.CUSTOMER_ONLINE_PAYMENT);
+        incomingNewContractStatusUpdate.setSource(eventSource);
         customerOnlinePaymentRecorderService = new CustomerOnlinePaymentRecorderService(customerOnlinePaymentBusinessTransactionDao,eventManager,errorManager);
-        //customerOnlinePaymentRecorderService.incomingNewContractStatusUpdateEventHandler(incomingNewContractStatusUpdate);
-    }*/
-
-    @Test(expected = Exception.class)
-    public void incomingNewContractStatusUpdateEventHandlerTest_Should_Throw_Exception() throws Exception {
-        customerOnlinePaymentRecorderService = new CustomerOnlinePaymentRecorderService(customerOnlinePaymentBusinessTransactionDao,eventManager,errorManager);
-        customerOnlinePaymentRecorderService.setEventManager(eventManager);
-        customerOnlinePaymentRecorderService.start();
-        customerOnlinePaymentRecorderService.incomingNewContractStatusUpdateEventHandler(null);
-    }
-
-    @Test(expected = CantSaveEventException.class)
-    public void incomingNewContractStatusUpdateEventHandlerTest_Should_Throw_CantSaveEventException() throws Exception {
-        customerOnlinePaymentRecorderService = new CustomerOnlinePaymentRecorderService(customerOnlinePaymentBusinessTransactionDao,eventManager,errorManager);
-        customerOnlinePaymentRecorderService.setEventManager(eventManager);
-        customerOnlinePaymentRecorderService.start();
         customerOnlinePaymentRecorderService.incomingNewContractStatusUpdateEventHandler(incomingNewContractStatusUpdate);
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/event_handler/CustomerOnlinePaymentRecorderServiceTest/testStart.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/event_handler/CustomerOnlinePaymentRecorderServiceTest/testStart.java
@@ -1,9 +1,9 @@
 package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.event_handler.CustomerOnlinePaymentRecorderServiceTest;
 
-import com.bitdubai.fermat_api.Service;
 import com.bitdubai.fermat_api.layer.all_definition.enums.ServiceStatus;
 import com.bitdubai.fermat_api.layer.all_definition.events.interfaces.FermatEventListener;
 import com.bitdubai.fermat_cbp_api.all_definition.events.enums.EventType;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.CantStartServiceException;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.event_handler.CustomerOnlinePaymentRecorderService;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
@@ -12,13 +12,10 @@ import com.bitdubai.fermat_pip_api.layer.platform_service.event_manager.interfac
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
@@ -56,11 +53,10 @@ public class testStart {
         assertEquals(ServiceStatus.STARTED, customerOnlinePaymentRecorderService.getStatus());
     }
 
-    @Test(expected = Exception.class)
+    @Test(expected = CantStartServiceException.class)
     public void testStart_Should_Return_Exception() throws Exception {
-        customerOnlinePaymentRecorderService = new CustomerOnlinePaymentRecorderService(null,null,null);
+        customerOnlinePaymentRecorderService = new CustomerOnlinePaymentRecorderService(null,null,errorManager);
         customerOnlinePaymentRecorderService.start();
-        //FALTA CONFIRMACION!!!!!
     }
 
     @Test

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/exceptions/CantInitializeCustomerOnlinePaymentBusinessTransactionDatabaseExceptionTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/exceptions/CantInitializeCustomerOnlinePaymentBusinessTransactionDatabaseExceptionTest.java
@@ -1,19 +1,15 @@
 package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.exceptions;
 
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
-import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseFilterType;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
-import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDatabaseConstants;
-import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.exceptions.CantInitializeCustomerOnlinePaymentBusinessTransactionDatabaseException;
 import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
 
 import java.util.UUID;
 
@@ -23,7 +19,7 @@ import java.util.UUID;
 public class CantInitializeCustomerOnlinePaymentBusinessTransactionDatabaseExceptionTest {
     @Mock
     private PluginDatabaseSystem mockPluginDatabaseSystem;
-
+    @Mock
     private Database mockDatabase;
     @Mock
     private DatabaseTable databaseTable;
@@ -31,19 +27,17 @@ public class CantInitializeCustomerOnlinePaymentBusinessTransactionDatabaseExcep
     ErrorManager errorManager;
     private UUID testId;
     private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDao;
-    private CustomerOnlinePaymentBusinessTransactionDao customerOnlinePaymentBusinessTransactionDaoSpy;
 
     @Before
     public void setup()throws Exception{
         testId = UUID.randomUUID();
-        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
-        customerOnlinePaymentBusinessTransactionDaoSpy = PowerMockito.spy(customerOnlinePaymentBusinessTransactionDao);
         MockitoAnnotations.initMocks(this);
-        PowerMockito.doReturn(databaseTable).when(customerOnlinePaymentBusinessTransactionDaoSpy, "getDatabaseContractTable");
-    }/*
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(mockPluginDatabaseSystem,testId, mockDatabase,errorManager);
+    }
     @Test(expected = CantInitializeCustomerOnlinePaymentBusinessTransactionDatabaseException.class)
     public void CustomerOnlinePaymentBusinessTransactionDaoInitTest()throws Exception{
-        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(null,null,mockDatabase,null);
+        customerOnlinePaymentBusinessTransactionDao = new CustomerOnlinePaymentBusinessTransactionDao(null,null,mockDatabase,errorManager);
         customerOnlinePaymentBusinessTransactionDao.initialize();
-    }*/
+
+    }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/structure/CustomerOnlinePaymentMonitorAgentTest/startTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/structure/CustomerOnlinePaymentMonitorAgentTest/startTest.java
@@ -2,7 +2,11 @@ package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_onlin
 
 import com.bitdubai.fermat_api.layer.all_definition.enums.ServiceStatus;
 import com.bitdubai.fermat_api.layer.all_definition.util.Version;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.exceptions.CantCreateDatabaseException;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.exceptions.CantOpenDatabaseException;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.exceptions.DatabaseNotFoundException;
 import com.bitdubai.fermat_api.layer.osa_android.logger_system.LogManager;
 import com.bitdubai.fermat_cbp_api.layer.contract.customer_broker_purchase.interfaces.CustomerBrokerContractPurchaseManager;
 import com.bitdubai.fermat_cbp_api.layer.contract.customer_broker_sale.interfaces.CustomerBrokerContractSaleManager;
@@ -15,17 +19,9 @@ import com.bitdubai.fermat_pip_api.layer.platform_service.event_manager.interfac
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 01/02/16.
@@ -85,9 +81,18 @@ public class startTest {
         customerOnlinePaymentMonitorAgent.stop();
 
     }
+
+    //private void setIntraActorCryptoTransactionManager
     @Test(expected = Exception.class)
-    public void testStart_Should_Return_Exception() throws Exception {
+    public void testsetIntraActorCryptoTransactionManager() throws Exception {
         customerOnlinePaymentMonitorAgent = new CustomerOnlinePaymentMonitorAgent(null,null,null,null,null,null,null,null,null);
-        customerOnlinePaymentMonitorAgent.start();
     }
+    //generic exception
+    @Test
+    public void testStart_Should_() throws Exception {
+        customerOnlinePaymentMonitorAgent = new CustomerOnlinePaymentMonitorAgent(null,logManager,errorManager,null,null,null,null,null,outgoingIntraActorManager);
+        customerOnlinePaymentMonitorAgent.start();
+        //verify(errorManager,times(1));
+    }
+
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/structure/CustomerOnlinePaymentTransactionManagerTest/getContractTransactionStatusTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/structure/CustomerOnlinePaymentTransactionManagerTest/getContractTransactionStatusTest.java
@@ -1,6 +1,7 @@
 package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.structure.CustomerOnlinePaymentTransactionManagerTest;
 
 import com.bitdubai.fermat_cbp_api.all_definition.enums.ContractTransactionStatus;
+import com.bitdubai.fermat_cbp_api.all_definition.exceptions.UnexpectedResultReturnedFromDatabaseException;
 import com.bitdubai.fermat_cbp_api.layer.contract.customer_broker_purchase.interfaces.CustomerBrokerContractPurchaseManager;
 import com.bitdubai.fermat_cbp_api.layer.negotiation.customer_broker_purchase.interfaces.CustomerBrokerPurchaseNegotiationManager;
 import com.bitdubai.fermat_cbp_api.layer.network_service.transaction_transmission.interfaces.TransactionTransmissionManager;
@@ -21,6 +22,7 @@ import static org.mockito.Mockito.when;
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 18/02/16.
  */
 public class getContractTransactionStatusTest {
+
     CustomerOnlinePaymentTransactionManager customerOnlinePaymentTransactionManager;
     @Mock
     CustomerBrokerContractPurchaseManager customerBrokerContractPurchaseManager;
@@ -43,14 +45,24 @@ public class getContractTransactionStatusTest {
         customerOnlinePaymentTransactionManager = new CustomerOnlinePaymentTransactionManager(customerBrokerContractPurchaseManager,
                 customerOnlinePaymentBusinessTransactionDao,
                 transactionTransmissionManager,
-                customerBrokerPurchaseNegotiationManager);
-
-        assertNotNull(customerOnlinePaymentTransactionManager.getContractTransactionStatus(""));
+                customerBrokerPurchaseNegotiationManager,
+                errorManager);
+        assertNotNull(customerOnlinePaymentTransactionManager.getContractTransactionStatus("Test"));
     }
 
-    @Test(expected = Exception.class)
-    public void getContractTransactionStatusTest_Should_Throw_Exception() throws Exception{
-        customerOnlinePaymentTransactionManager = new CustomerOnlinePaymentTransactionManager(null,null,null,null);
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
+    public void getContractTransactionStatusTest_Should_Throw_UnexpectedResultReturnedFromDatabaseException() throws Exception{
+        customerOnlinePaymentTransactionManager = new CustomerOnlinePaymentTransactionManager(customerBrokerContractPurchaseManager,
+                customerOnlinePaymentBusinessTransactionDao,
+                transactionTransmissionManager,
+                customerBrokerPurchaseNegotiationManager,
+                errorManager);
         customerOnlinePaymentTransactionManager.getContractTransactionStatus(null);
+    }
+
+    @Test(expected = UnexpectedResultReturnedFromDatabaseException.class)
+    public void getContractTransactionStatusTest_Should_Throw_Generic_UnexpectedResultReturnedFromDatabaseException() throws Exception{
+        customerOnlinePaymentTransactionManager = new CustomerOnlinePaymentTransactionManager(null,null,null,null,errorManager);
+        customerOnlinePaymentTransactionManager.getContractTransactionStatus("Test");
     }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/structure/CustomerOnlinePaymentTransactionManagerTest/parseToLongTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/structure/CustomerOnlinePaymentTransactionManagerTest/parseToLongTest.java
@@ -6,14 +6,22 @@ import com.bitdubai.fermat_cbp_api.layer.negotiation.customer_broker_purchase.in
 import com.bitdubai.fermat_cbp_api.layer.network_service.transaction_transmission.interfaces.TransactionTransmissionManager;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.database.CustomerOnlinePaymentBusinessTransactionDao;
 import com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.structure.CustomerOnlinePaymentTransactionManager;
+import com.bitdubai.fermat_pip_api.layer.platform_service.error_manager.interfaces.ErrorManager;
 
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 04/02/16.
  */
 public class parseToLongTest {
+    private CustomerOnlinePaymentTransactionManager customerOnlinePaymentTransactionManager;
+
     @Mock
     CustomerBrokerContractPurchaseManager customerBrokerContractPurchaseManager;
     @Mock
@@ -22,21 +30,23 @@ public class parseToLongTest {
     TransactionTransmissionManager transactionTransmissionManager;
     @Mock
     CustomerBrokerPurchaseNegotiationManager customerBrokerPurchaseNegotiationManager;
-    CustomerOnlinePaymentTransactionManager customerOnlinePaymentTransactionManager;
-
-    @Test
-    public void parseToLongTest_Should_Return_Long()throws Exception{
-        customerOnlinePaymentTransactionManager = new CustomerOnlinePaymentTransactionManager(customerBrokerContractPurchaseManager,customerOnlinePaymentBusinessTransactionDao,transactionTransmissionManager,customerBrokerPurchaseNegotiationManager);
-        customerOnlinePaymentTransactionManager.parseToLong("1");
+    @Mock
+    ErrorManager errorManager;
+    @Before
+    public void setup(){
+        MockitoAnnotations.initMocks(this);
+        customerOnlinePaymentTransactionManager = new CustomerOnlinePaymentTransactionManager(customerBrokerContractPurchaseManager,customerOnlinePaymentBusinessTransactionDao,transactionTransmissionManager,customerBrokerPurchaseNegotiationManager,errorManager);
     }
     @Test(expected = InvalidParameterException.class)
-    public void parseToLongTest_Should_Return_null_InvalidParameterException()throws Exception{
-        customerOnlinePaymentTransactionManager = new CustomerOnlinePaymentTransactionManager(customerBrokerContractPurchaseManager,customerOnlinePaymentBusinessTransactionDao,transactionTransmissionManager,customerBrokerPurchaseNegotiationManager);
+    public void parseToLongTest_Should_Throw_Null_InvalidParameterException() throws  Exception{
         customerOnlinePaymentTransactionManager.parseToLong(null);
-    }/*
+    }
+    @Test
+    public void parseToLongTest_Should_Return_Long() throws  Exception{
+        assertEquals(customerOnlinePaymentTransactionManager.parseToLong("1"),1);
+    }
     @Test(expected = InvalidParameterException.class)
-    public void parseToLongTest_Should_Return_long_InvalidParameterException()throws Exception{
-        customerOnlinePaymentTransactionManager = new CustomerOnlinePaymentTransactionManager(customerBrokerContractPurchaseManager,customerOnlinePaymentBusinessTransactionDao,transactionTransmissionManager,customerBrokerPurchaseNegotiationManager);
-        customerOnlinePaymentTransactionManager.parseToLong("A");
-    }*/
+    public void parseToLongTest_Should_() throws  Exception{
+        customerOnlinePaymentTransactionManager.parseToLong("Test");
+    }
 }

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/structure/CustomerOnlinePaymentTransactionManagerTest/sendPaymentTest.java
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/src/test/java/com/bitdubai/fermat_cbp_plugin/layer/business_transaction/customer_online_payment/developer/bitdubai/version_1/structure/CustomerOnlinePaymentTransactionManagerTest/sendPaymentTest.java
@@ -1,6 +1,8 @@
 package com.bitdubai.fermat_cbp_plugin.layer.business_transaction.customer_online_payment.developer.bitdubai.version_1.structure.CustomerOnlinePaymentTransactionManagerTest;
 
 import com.bitdubai.fermat_cbp_api.layer.business_transaction.common.exceptions.CantSendPaymentException;
+import com.bitdubai.fermat_cbp_api.layer.business_transaction.common.mocks.PurchaseNegotiationOnlineMock;
+import com.bitdubai.fermat_cbp_api.layer.contract.customer_broker_purchase.interfaces.CustomerBrokerContractPurchase;
 import com.bitdubai.fermat_cbp_api.layer.contract.customer_broker_purchase.interfaces.CustomerBrokerContractPurchaseManager;
 import com.bitdubai.fermat_cbp_api.layer.negotiation.customer_broker_purchase.interfaces.CustomerBrokerPurchaseNegotiationManager;
 import com.bitdubai.fermat_cbp_api.layer.network_service.transaction_transmission.interfaces.TransactionTransmissionManager;
@@ -12,6 +14,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import java.util.UUID;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by alexander jimenez (alex_jimenez76@hotmail.com) on 18/02/16.
@@ -29,32 +36,54 @@ public class sendPaymentTest {
     TransactionTransmissionManager transactionTransmissionManager;
     @Mock
     CustomerBrokerPurchaseNegotiationManager customerBrokerPurchaseNegotiationManager;
+    @Mock
+    CustomerBrokerContractPurchase customerBrokerContractPurchase;
+    PurchaseNegotiationOnlineMock purchaseNegotiationOnlineMock = new PurchaseNegotiationOnlineMock();
+    //@Mock
+    //Collection<Clause> collection;
+
+    //@Mock
+    //Iterator<Clause> iterator;
+
     @Before
     public void setup() throws Exception{
         MockitoAnnotations.initMocks(this);
-    }
-
-    /*@Test
-    public void sendPaymentTest_Should() throws Exception{
         customerOnlinePaymentTransactionManager = new CustomerOnlinePaymentTransactionManager(customerBrokerContractPurchaseManager,
                 customerOnlinePaymentBusinessTransactionDao,
                 transactionTransmissionManager,
-                customerBrokerPurchaseNegotiationManager);
-        customerOnlinePaymentTransactionManager.sendPayment("","");
-    }*/
-/*
+                customerBrokerPurchaseNegotiationManager,
+                errorManager);
+        setUpGeneralMockitoRules();
+    }
+    public void setUpGeneralMockitoRules() throws Exception{
+        when(customerBrokerContractPurchaseManager.getCustomerBrokerContractPurchaseForContractId(anyString())).thenReturn(customerBrokerContractPurchase);
+        when(customerBrokerContractPurchase.getNegotiatiotId()).thenReturn("00000000-0000-0000-C000-000000000046");
+        UUID negotiationUUID=UUID.fromString("00000000-0000-0000-C000-000000000046");
+        when(customerBrokerPurchaseNegotiationManager.getNegotiationsByNegotiationId(negotiationUUID)).thenReturn(purchaseNegotiationOnlineMock);
+
+
+    }
+
+    @Test
+    public void sendPaymentTest_Should() throws Exception{
+        customerOnlinePaymentTransactionManager.sendPayment("walletPublicKey", "contractHash");
+    }
+
+    //ObjectNotSetException
+    @Test(expected = CantSendPaymentException.class)
+    public void sendPaymentTest_Should_() throws Exception{
+
+        customerOnlinePaymentTransactionManager.sendPayment(null, "contractHash");
+    }
+    //Generic Exception
     @Test(expected = CantSendPaymentException.class)
     public void sendPaymentTest_Should_Throw_CantSendPaymentException() throws Exception{
         customerOnlinePaymentTransactionManager = new CustomerOnlinePaymentTransactionManager(null,
                 customerOnlinePaymentBusinessTransactionDao,
                 transactionTransmissionManager,
-                customerBrokerPurchaseNegotiationManager);
+                customerBrokerPurchaseNegotiationManager,
+                errorManager);
         customerOnlinePaymentTransactionManager.sendPayment("","");
-    }*/
-
-    @Test(expected = Exception.class)
-    public void sendPaymentTest_Should_Throw_Exception() throws Exception{
-        customerOnlinePaymentTransactionManager = new CustomerOnlinePaymentTransactionManager(null,null,null,null);
-        customerOnlinePaymentTransactionManager.sendPayment(null,null);
     }
+
 }


### PR DESCRIPTION
Fixes #4516 and #4927 

Changes proposed in this pull request:

* fixes in CustomerOnlinPaymentBusinessTransactionDaoTest to implement Mockito and eliminate the use of PowerMockito.

* fix in CustomerOnlinePaymentBusinessTransactionDao class to change 2 previously changed methods from private to protected

* fix an error in CustomerOnlinePaymentTransactionManager in wich errorManager was null

* fix in build.gradle to eliminate powerMockito

* fix to all unit test to implement errorManager that required it

@darkestpriest