### PR TITLE
Fix: fix error while creating identity without a picture and while loading identity

### DIFF
--- a/ART/android/sub_app/fermat-art-android-sub-app-fan-identity-bitdubai/src/main/java/com/bitdubai/sub_app/art_fan_identity/fragments/CreateArtFanUserIdentityFragment.java
+++ b/ART/android/sub_app/fermat-art-android-sub-app-fan-identity-bitdubai/src/main/java/com/bitdubai/sub_app/art_fan_identity/fragments/CreateArtFanUserIdentityFragment.java
@@ -198,6 +198,7 @@ public class CreateArtFanUserIdentityFragment extends AbstractFermatFragment {
         return stream.toByteArray();
     }
     private void loadIdentity(){
+        //System.out.println("Image is : " + identitySelected.getProfileImage());
         if (identitySelected.getProfileImage() != null) {
             Bitmap bitmap = null;
             if (identitySelected.getProfileImage().length > 0) {
@@ -219,13 +220,13 @@ public class CreateArtFanUserIdentityFragment extends AbstractFermatFragment {
         ArrayAdapter<String> adapter = new ArrayAdapter<String>(getActivity(), android.R.layout.simple_spinner_item, arraySpinner);
         mFanExternalPlatform.setAdapter(adapter);
         ArtExternalPlatform[] externalPlatforms = ArtExternalPlatform.values();
-        for (int i=0; i<externalPlatforms.length;i++){
+        /*for (int i=0; i<externalPlatforms.length;i++){
             if(externalPlatforms[i].getCode().equals(
                     identitySelected.getExternalPlatform().getCode())){
                 mFanExternalPlatform.setSelection(i);
                 break;
             }
-        }
+        }*/
     }
     /**
      * Initialize the views from this fragment
@@ -296,6 +297,7 @@ public class CreateArtFanUserIdentityFragment extends AbstractFermatFragment {
             externalPlatform = ArtExternalPlatform.getArtExternalPlatformByLabel(
                     mFanExternalPlatform.getSelectedItem().toString());
         }
+        fanImageByteArray = convertImage(R.drawable.ic_profile_male);
         boolean dataIsValid = validateIdentityData(
                 fanExternalName,
                 fanImageByteArray,
@@ -364,10 +366,12 @@ public class CreateArtFanUserIdentityFragment extends AbstractFermatFragment {
             ArtExternalPlatform externalPlatform) {
         if (fanExternalName.isEmpty())
             return false;
-        if (fanImageBytes == null)
+        if (externalPlatformID==null)
+            return false;
+        /*if (fanImageBytes == null)
             return false;
         if (fanImageBytes.length > 0)
-            return true;
+            return true;*/
 //        if(externalPlatform != null)
 //            return  true;
         return true;
@@ -541,6 +545,8 @@ public class CreateArtFanUserIdentityFragment extends AbstractFermatFragment {
             moduleManager.createFanaticIdentity(
                     fanExternalName,(fanImageByteArray == null) ? convertImage(R.drawable.ic_profile_male) : fanImageByteArray,
                     externalPlatformID) ;
+        }else{
+
         }
     }
 


### PR DESCRIPTION
Fix error while creating identity without a picture, the toast print a "identity Created" but didn't do it

Fix error while loading identity

Include in: #6054,#5979
