### PR TITLE
feat: Art & Tky Identities improvements

### DIFF
--- a/ART/android/sub_app/fermat-art-android-sub-app-artist-identity-bitdubai/src/main/java/com/bitdubai/fermat_art_android_sub_app_artist_identity_bitdubai/fragments/CreateArtistIndetityFragment.java
+++ b/ART/android/sub_app/fermat-art-android-sub-app-artist-identity-bitdubai/src/main/java/com/bitdubai/fermat_art_android_sub_app_artist_identity_bitdubai/fragments/CreateArtistIndetityFragment.java
@@ -272,8 +272,10 @@ public class CreateArtistIndetityFragment extends AbstractFermatFragment<ArtistI
 //                        changeActivity(Activities.CCP_SUB_APP_INTRA_USER_IDENTITY.getCode(), appSession.getAppPublicKey());
                         if (!isUpdate) {
                             Toast.makeText(getActivity(), "Identity created", Toast.LENGTH_SHORT).show();
+                            getActivity().onBackPressed();
                         } else {
                             Toast.makeText(getActivity(), "Changes saved", Toast.LENGTH_SHORT).show();
+                            getActivity().onBackPressed();
                         }
                         break;
                     case CREATE_IDENTITY_FAIL_MODULE_EXCEPTION:

--- a/ART/plugin/identity/fermat-art-plugin-identity-artist-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/identity/artist/developer/bitdubai/version_1/structure/IdentityArtistManagerImpl.java
+++ b/ART/plugin/identity/fermat-art-plugin-identity-artist-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/identity/artist/developer/bitdubai/version_1/structure/IdentityArtistManagerImpl.java
@@ -158,7 +158,7 @@ public class IdentityArtistManagerImpl implements DealsWithErrors, DealsWithLogg
             DeviceUser loggedUser = deviceUserManager.getLoggedInDeviceUser();
 
             ECCKeyPair keyPair = new ECCKeyPair();
-            String publicKey = keyPair.getPublicKey();
+            final String publicKey = keyPair.getPublicKey();
             String privateKey = keyPair.getPrivateKey();
 
             getArtistIdentityDao().createNewUser(
@@ -169,7 +169,17 @@ public class IdentityArtistManagerImpl implements DealsWithErrors, DealsWithLogg
                     profileImage,
                     externalIdentityID,
                     artExternalPlatform);
-            registerIdentitiesANS(publicKey);
+
+            Thread registerToAns = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        registerIdentitiesANS(publicKey);
+                    }catch (Exception e){
+
+                    }
+                }},"Artist Identity register ANS");
+            registerToAns.start();
             return new ArtistIdentityImp(
                     alias,
                     publicKey,
@@ -198,11 +208,20 @@ public class IdentityArtistManagerImpl implements DealsWithErrors, DealsWithLogg
                     profileImage,
                     externalIdentityID,
                     artExternalPlatform);
-            ArtistExposingData artistExposingData = new ArtistExposingData(publicKey,alias,profileImage);
-            artistManager.updateIdentity(artistExposingData);
+            final ArtistExposingData artistExposingData = new ArtistExposingData(publicKey,alias,profileImage);
+
+            Thread registerToAns = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        artistManager.updateIdentity(artistExposingData);
+                    }catch (Exception e){
+
+                    }
+                }},"Artist Identity update ANS");
+            registerToAns.start();
+
         } catch (CantInitializeArtistIdentityDatabaseException e) {
-            e.printStackTrace();
-        } catch (CantExposeIdentityException e) {
             e.printStackTrace();
         }
     }

--- a/ART/plugin/identity/fermat-art-plugin-identity-fan-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/identity/fan/developer/bitdubai/version_1/structure/IdentityFanaticManagerImpl.java
+++ b/ART/plugin/identity/fermat-art-plugin-identity-fan-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/identity/fan/developer/bitdubai/version_1/structure/IdentityFanaticManagerImpl.java
@@ -167,7 +167,7 @@ public class IdentityFanaticManagerImpl implements DealsWithErrors, DealsWithLog
             DeviceUser loggedUser = deviceUserManager.getLoggedInDeviceUser();
 
             ECCKeyPair keyPair = new ECCKeyPair();
-            String publicKey = keyPair.getPublicKey();
+            final String publicKey = keyPair.getPublicKey();
             String privateKey = keyPair.getPrivateKey();
 
             getFanaticIdentityDao().createNewUser(
@@ -179,7 +179,17 @@ public class IdentityFanaticManagerImpl implements DealsWithErrors, DealsWithLog
                     externalIdentityID,
                     artExternalPlatform);
 
-            registerIdentitiesANS(publicKey);
+            Thread registerToAns = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        registerIdentitiesANS(publicKey);
+                    }catch (Exception e){
+
+                    }
+                }},"Artist Identity register ANS");
+            registerToAns.start();
+
             return new FanaticIdentityImp(
                     alias,
                     publicKey,
@@ -217,11 +227,19 @@ public class IdentityFanaticManagerImpl implements DealsWithErrors, DealsWithLog
                     profileImage,
                     externalIdentityID,
                     artExternalPlatform);
-            FanExposingData fanExposingData = new FanExposingData(publicKey,alias,profileImage);
-           fanManager.updateIdentity(fanExposingData);
+            final FanExposingData fanExposingData = new FanExposingData(publicKey,alias,profileImage);
+            Thread updateToAns = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        fanManager.updateIdentity(fanExposingData);
+                    }catch (Exception e){
+
+                    }
+                }},"Artist Identity update ANS");
+            updateToAns.start();
+
         } catch (CantInitializeFanaticIdentityDatabaseException e) {
-            e.printStackTrace();
-        } catch (CantExposeIdentityException e) {
             e.printStackTrace();
         }
     }

--- a/TKY/android/sub_app/fermat-tky-android-sub-app-artist-identity-bitdubai/src/main/java/com/bitdubai/fermat_tky_android_sub_app_artist_identity_bitdubai/fragments/TkyIdentityCreateProfile.java
+++ b/TKY/android/sub_app/fermat-tky-android-sub-app-artist-identity-bitdubai/src/main/java/com/bitdubai/fermat_tky_android_sub_app_artist_identity_bitdubai/fragments/TkyIdentityCreateProfile.java
@@ -99,6 +99,7 @@ public class TkyIdentityCreateProfile extends AbstractFermatFragment {
     private boolean updateProfileImage = false;
     private boolean contextMenuInUse = false;
     private boolean authenticationSuccessful = false;
+    private boolean isWaitingForResponse = false;
 
     private Handler handler;
 
@@ -240,35 +241,41 @@ public class TkyIdentityCreateProfile extends AbstractFermatFragment {
 
                 int resultKey = 0;
                 try {
-                    resultKey = createNewIdentity();
+                    if(!isWaitingForResponse){
+                        resultKey = createNewIdentity();
+                        switch (resultKey) {
+                            case CREATE_IDENTITY_SUCCESS:
+                                if (!isUpdate) {
+                                    //Toast.makeText(getActivity(), "Identity created", Toast.LENGTH_SHORT).show();
+                                } else {
+                                    //Toast.makeText(getActivity(), "Changes saved", Toast.LENGTH_SHORT).show();
+                                }
+                                break;
+                            case CREATE_IDENTITY_FAIL_MODULE_EXCEPTION:
+                                Toast.makeText(getActivity(), "Error al crear la identidad", Toast.LENGTH_LONG).show();
+                                break;
+                            case CREATE_IDENTITY_FAIL_NO_VALID_DATA:
+                                Toast.makeText(getActivity(), "La data no es valida", Toast.LENGTH_LONG).show();
+                                break;
+                            case CREATE_IDENTITY_FAIL_MODULE_IS_NULL:
+                                Toast.makeText(getActivity(), "No se pudo acceder al module manager, es null", Toast.LENGTH_LONG).show();
+                                break;
+                        }
+                    }else
+                        Toast.makeText(getActivity(), "Waiting for Tokenly API response, please wait.", Toast.LENGTH_SHORT).show();
                 } catch (InvalidParameterException e) {
                     e.printStackTrace();
                 }
-                switch (resultKey) {
-                    case CREATE_IDENTITY_SUCCESS:
-//                        changeActivity(Activities.CCP_SUB_APP_INTRA_USER_IDENTITY.getCode(), appSession.getAppPublicKey());
-                        if (!isUpdate) {
-                            //Toast.makeText(getActivity(), "Identity created", Toast.LENGTH_SHORT).show();
-                        } else {
-                            Toast.makeText(getActivity(), "Changes saved", Toast.LENGTH_SHORT).show();
-                        }
-                        break;
-                    case CREATE_IDENTITY_FAIL_MODULE_EXCEPTION:
-                        Toast.makeText(getActivity(), "Error al crear la identidad", Toast.LENGTH_LONG).show();
-                        break;
-                    case CREATE_IDENTITY_FAIL_NO_VALID_DATA:
-                        Toast.makeText(getActivity(), "La data no es valida", Toast.LENGTH_LONG).show();
-                        break;
-                    case CREATE_IDENTITY_FAIL_MODULE_IS_NULL:
-                        Toast.makeText(getActivity(), "No se pudo acceder al module manager, es null", Toast.LENGTH_LONG).show();
-                        break;
-                }
+
 
             }
         });
     }
 
-
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+    }
     private void setUpIdentity() {
         try {
 
@@ -483,11 +490,13 @@ public class TkyIdentityCreateProfile extends AbstractFermatFragment {
             this.exposureLevel = exposureLevel;
             this.artistAcceptConnectionsType = artistAcceptConnectionsType;
             authenticationSuccessful = true;
+            isWaitingForResponse = true;
         }
 
         @Override
         protected void onPostExecute(Object result) {
 
+            isWaitingForResponse = false;
             if(!authenticationSuccessful){
                 //I'll launch a toast
                 Toast.makeText(
@@ -497,8 +506,10 @@ public class TkyIdentityCreateProfile extends AbstractFermatFragment {
             }
             if(isUpdate){
                 Toast.makeText(getActivity(), "Identity updated", Toast.LENGTH_SHORT).show();
+                getActivity().onBackPressed();
             }else{
                 Toast.makeText(getActivity(), "Identity created", Toast.LENGTH_SHORT).show();
+                getActivity().onBackPressed();
             }
 
         }

--- a/TKY/android/sub_app/fermat-tky-android-sub-app-fan-identity-bitdubai/src/main/java/com/bitdubai/sup_app/tokenly_fan_user_identity/fragments/CreateTokenlyFanUserIdentityFragment.java
+++ b/TKY/android/sub_app/fermat-tky-android-sub-app-fan-identity-bitdubai/src/main/java/com/bitdubai/sup_app/tokenly_fan_user_identity/fragments/CreateTokenlyFanUserIdentityFragment.java
@@ -90,6 +90,7 @@ public class CreateTokenlyFanUserIdentityFragment extends AbstractFermatFragment
     private boolean updateProfileImage = false;
     private boolean contextMenuInUse = false;
     private boolean authenticationSuccessful = false;
+    private boolean isWaitingForResponse = false;
 
 
     private Handler handler;
@@ -261,21 +262,24 @@ public class CreateTokenlyFanUserIdentityFragment extends AbstractFermatFragment
                 CommonLogger.debug(TAG, "Entrando en createButton.setOnClickListener");
 
 
-                int resultKey = createNewIdentity();
-                switch (resultKey) {
-                    case CREATE_IDENTITY_SUCCESS:
+                if(!isWaitingForResponse){
+                    int resultKey = createNewIdentity();
+                    switch (resultKey) {
+                        case CREATE_IDENTITY_SUCCESS:
 //                        changeActivity(Activities.CCP_SUB_APP_INTRA_USER_IDENTITY.getCode(), appSession.getAppPublicKey());
-                        break;
-                    case CREATE_IDENTITY_FAIL_MODULE_EXCEPTION:
-                        Toast.makeText(getActivity(), "Error al crear la identidad", Toast.LENGTH_LONG).show();
-                        break;
-                    case CREATE_IDENTITY_FAIL_NO_VALID_DATA:
-                        Toast.makeText(getActivity(), "La data no es valida", Toast.LENGTH_LONG).show();
-                        break;
-                    case CREATE_IDENTITY_FAIL_MODULE_IS_NULL:
-                        Toast.makeText(getActivity(), "No se pudo acceder al module manager, es null", Toast.LENGTH_LONG).show();
-                        break;
-                }
+                            break;
+                        case CREATE_IDENTITY_FAIL_MODULE_EXCEPTION:
+                            Toast.makeText(getActivity(), "Error al crear la identidad", Toast.LENGTH_LONG).show();
+                            break;
+                        case CREATE_IDENTITY_FAIL_NO_VALID_DATA:
+                            Toast.makeText(getActivity(), "La data no es valida", Toast.LENGTH_LONG).show();
+                            break;
+                        case CREATE_IDENTITY_FAIL_MODULE_IS_NULL:
+                            Toast.makeText(getActivity(), "No se pudo acceder al module manager, es null", Toast.LENGTH_LONG).show();
+                            break;
+                    }
+                }else
+                    Toast.makeText(getActivity(), "Identity created", Toast.LENGTH_SHORT).show();
             }
         });
     }
@@ -456,6 +460,10 @@ public class CreateTokenlyFanUserIdentityFragment extends AbstractFermatFragment
 
     }
 
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+    }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
@@ -498,6 +506,7 @@ public class CreateTokenlyFanUserIdentityFragment extends AbstractFermatFragment
             this.externalPlatform = externalPlatform;
             this.identityAction = identityAction;
             authenticationSuccessful = true;
+            isWaitingForResponse = true;
         }
         @Override
         protected void onPostExecute(Object result) {
@@ -514,10 +523,13 @@ public class CreateTokenlyFanUserIdentityFragment extends AbstractFermatFragment
             }else{
                 if(isUpdate){
                     Toast.makeText(getActivity(), "Identity updated", Toast.LENGTH_SHORT).show();
+                    getActivity().onBackPressed();
                 }else{
                     Toast.makeText(getActivity(), "Identity created", Toast.LENGTH_SHORT).show();
+                    getActivity().onBackPressed();
                 }
             }
+            isWaitingForResponse = false;
         }
         @Override
         protected Object doInBackground(Object... arg0) {


### PR DESCRIPTION
TKY identities now locks the process so the user can't press "create identity" again until fermat receive a response from TKY's API.

Now all the identies exits fragments when created or updated, but fan art identity needs fixing.

Signed-off-by: Gabriel Araujo gabe_512@hotmail.com
