### PR TITLE
ART - Actor Network Service - register identity on connection loose

### DIFF
--- a/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-artist-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/artist/developer/bitdubai/version_1/ArtistActorNetworkServicePluginRoot.java
+++ b/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-artist-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/artist/developer/bitdubai/version_1/ArtistActorNetworkServicePluginRoot.java
@@ -4,8 +4,10 @@ package com.bitdubai.fermat_art_plugin.layer.actor_network_service.artist.develo
 
 import com.bitdubai.fermat_api.CantStartPluginException;
 import com.bitdubai.fermat_api.layer.all_definition.common.system.interfaces.FermatManager;
+import com.bitdubai.fermat_api.layer.all_definition.common.system.utils.PluginReference;
 import com.bitdubai.fermat_api.layer.all_definition.common.system.utils.PluginVersionReference;
 import com.bitdubai.fermat_api.layer.all_definition.components.enums.PlatformComponentType;
+import com.bitdubai.fermat_api.layer.all_definition.components.interfaces.PlatformComponentProfile;
 import com.bitdubai.fermat_api.layer.all_definition.crypto.asymmetric.ECCKeyPair;
 import com.bitdubai.fermat_api.layer.all_definition.developer.DatabaseManagerForDevelopers;
 import com.bitdubai.fermat_api.layer.all_definition.developer.DeveloperDatabase;
@@ -425,8 +427,42 @@ public class ArtistActorNetworkServicePluginRoot extends AbstractNetworkServiceB
     protected void onNetworkServiceRegistered() {
 
         artistActorNetworkServiceManager.setPlatformComponentProfile(this.getNetworkServiceProfile());
+
+        runExposeIdentityThread();
         //testCreateAndList();
 
+    }
+
+    private void runExposeIdentityThread(){
+        final PluginVersionReference pluginReference = getPluginVersionReference();
+        Thread exposeIdentities = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    artistActorNetworkServiceManager.exposeIdentitiesInWait();
+                } catch (CantExposeIdentityException e) {
+                    errorManager.reportUnexpectedPluginException(pluginReference, UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN, e);
+                }
+            }
+        }, "REGISTER ARTIST IDENTITY CACHE");
+
+        exposeIdentities.start();
+    }
+    @Override
+    protected void onClientSuccessfulReconnect() {
+        final PluginVersionReference pluginReference = getPluginVersionReference();
+        Thread exposeIdentities = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    artistActorNetworkServiceManager.exposeIdentitiesInWait();
+                } catch (CantExposeIdentityException e) {
+                    errorManager.reportUnexpectedPluginException(pluginReference, UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN, e);
+                }
+            }
+        }, "REGISTER ARTIST IDENTITY CACHE");
+
+        exposeIdentities.start();
     }
 
     private void testCreateAndList(){

--- a/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-artist-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/artist/developer/bitdubai/version_1/structure/ArtistActorNetworkServiceManager.java
+++ b/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-artist-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/artist/developer/bitdubai/version_1/structure/ArtistActorNetworkServiceManager.java
@@ -5,6 +5,7 @@ import com.bitdubai.fermat_api.layer.all_definition.components.enums.PlatformCom
 import com.bitdubai.fermat_api.layer.all_definition.components.interfaces.PlatformComponentProfile;
 import com.bitdubai.fermat_api.layer.all_definition.network_service.enums.NetworkServiceType;
 import com.bitdubai.fermat_api.layer.all_definition.util.Base64;
+import com.bitdubai.fermat_api.layer.all_definition.util.Validate;
 import com.bitdubai.fermat_art_api.layer.actor_network_service.enums.ConnectionRequestAction;
 import com.bitdubai.fermat_art_api.layer.actor_network_service.enums.ProtocolState;
 import com.bitdubai.fermat_art_api.layer.actor_network_service.enums.RequestType;
@@ -82,6 +83,16 @@ public final class ArtistActorNetworkServiceManager implements ArtistManager {
 
     private ConcurrentHashMap<String, ArtistExposingData> artistsToExpose;
 
+    public final void exposeIdentitiesInWait() throws CantExposeIdentityException {
+        if(!Validate.isObjectNull(artistsToExpose) && artistsToExpose.size() > 0){
+            for (ArtistExposingData artistExposingData :
+                    artistsToExpose.values()) {
+                exposeIdentity(artistExposingData);
+            }
+        }
+    }
+
+
     @Override
     public final void exposeIdentity(final ArtistExposingData artist) throws CantExposeIdentityException {
 
@@ -105,9 +116,7 @@ public final class ArtistActorNetworkServiceManager implements ArtistManager {
                 );
 
                 communicationsClientConnection.registerComponentForCommunication(platformComponentProfile.getNetworkServiceType(), actorPlatformComponentProfile);
-
-                if (artistsToExpose != null && artistsToExpose.containsKey(artist.getPublicKey()))
-                    artistsToExpose.remove(artist.getPublicKey());
+                addArtistsToExpose(artist);
             }
 
         } catch (final CantRegisterComponentException e) {

--- a/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-fan-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/fan/developer/bitdubai/version_1/FanActorNetworkServicePluginRoot.java
+++ b/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-fan-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/fan/developer/bitdubai/version_1/FanActorNetworkServicePluginRoot.java
@@ -6,6 +6,7 @@ import com.bitdubai.fermat_api.CantStartPluginException;
 import com.bitdubai.fermat_api.layer.all_definition.common.system.interfaces.FermatManager;
 import com.bitdubai.fermat_api.layer.all_definition.common.system.utils.PluginVersionReference;
 import com.bitdubai.fermat_api.layer.all_definition.components.enums.PlatformComponentType;
+import com.bitdubai.fermat_api.layer.all_definition.components.interfaces.PlatformComponentProfile;
 import com.bitdubai.fermat_api.layer.all_definition.crypto.asymmetric.ECCKeyPair;
 import com.bitdubai.fermat_api.layer.all_definition.developer.DatabaseManagerForDevelopers;
 import com.bitdubai.fermat_api.layer.all_definition.developer.DeveloperDatabase;
@@ -339,9 +340,32 @@ public class FanActorNetworkServicePluginRoot extends AbstractNetworkServiceBase
     protected void onNetworkServiceRegistered() {
 
         fanActorNetworkServiceManager.setPlatformComponentProfile(this.getNetworkServiceProfile());
+        runExposeIdentityThread();
         //testCreateAndList();
 
     }
+
+    @Override
+    protected void onClientSuccessfulReconnect() {
+        runExposeIdentityThread();
+    }
+
+    private void runExposeIdentityThread(){
+        final PluginVersionReference pluginReference = getPluginVersionReference();
+        Thread exposeIdentities = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    fanActorNetworkServiceManager.exposeIdentitiesInWait();
+                } catch (CantExposeIdentityException e) {
+                    errorManager.reportUnexpectedPluginException(pluginReference, UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN, e);
+                }
+            }
+        }, "REGISTER ARTIST IDENTITY CACHE");
+
+        exposeIdentities.start();
+    }
+
 
     private void testCreateAndList(){
         ECCKeyPair identity = new ECCKeyPair();

--- a/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-fan-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/fan/developer/bitdubai/version_1/structure/FanActorNetworkServiceManager.java
+++ b/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-fan-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/fan/developer/bitdubai/version_1/structure/FanActorNetworkServiceManager.java
@@ -6,6 +6,7 @@ import com.bitdubai.fermat_api.layer.all_definition.common.system.utils.PluginVe
 import com.bitdubai.fermat_api.layer.all_definition.components.enums.PlatformComponentType;
 import com.bitdubai.fermat_api.layer.all_definition.components.interfaces.PlatformComponentProfile;
 import com.bitdubai.fermat_api.layer.all_definition.network_service.enums.NetworkServiceType;
+import com.bitdubai.fermat_api.layer.all_definition.util.Validate;
 import com.bitdubai.fermat_art_api.layer.actor_network_service.enums.ConnectionRequestAction;
 import com.bitdubai.fermat_art_api.layer.actor_network_service.enums.ProtocolState;
 import com.bitdubai.fermat_art_api.layer.actor_network_service.enums.RequestType;
@@ -20,6 +21,7 @@ import com.bitdubai.fermat_art_api.layer.actor_network_service.exceptions.CantLi
 import com.bitdubai.fermat_art_api.layer.actor_network_service.exceptions.CantRequestConnectionException;
 import com.bitdubai.fermat_art_api.layer.actor_network_service.exceptions.ConnectionRequestNotFoundException;
 import com.bitdubai.fermat_art_api.layer.actor_network_service.interfaces.ActorSearch;
+import com.bitdubai.fermat_art_api.layer.actor_network_service.interfaces.artist.util.ArtistExposingData;
 import com.bitdubai.fermat_art_api.layer.actor_network_service.interfaces.fan.FanManager;
 import com.bitdubai.fermat_art_api.layer.actor_network_service.interfaces.fan.util.FanConnectionInformation;
 import com.bitdubai.fermat_art_api.layer.actor_network_service.interfaces.fan.util.FanConnectionRequest;
@@ -81,6 +83,14 @@ public final class FanActorNetworkServiceManager implements FanManager {
 
     private ConcurrentHashMap<String, FanExposingData> fansToExpose;
 
+    public final void exposeIdentitiesInWait() throws CantExposeIdentityException {
+        if(!Validate.isObjectNull(fansToExpose) && fansToExpose.size() > 0){
+            for (FanExposingData fanExposingData :
+                    fansToExpose.values()) {
+                exposeIdentity(fanExposingData);
+            }
+        }
+    }
     @Override
     public final void exposeIdentity(final FanExposingData fan) throws CantExposeIdentityException {
 
@@ -104,9 +114,7 @@ public final class FanActorNetworkServiceManager implements FanManager {
                 );
 
                 communicationsClientConnection.registerComponentForCommunication(platformComponentProfile.getNetworkServiceType(), actorPlatformComponentProfile);
-
-                if (fansToExpose != null && fansToExpose.containsKey(fan.getPublicKey()))
-                    fansToExpose.remove(fan.getPublicKey());
+                addFansToExpose(fan);
             }
 
         } catch (final CantRegisterComponentException e) {


### PR DESCRIPTION
I set a thread to register identities in cache whenever the event onNetworkServiceRegistered and onClientSuccessfulReconnect
is thrown. But sometimes onClientSuccessfulReconnect is never thrown from P2P, needs testing.

Include in: #6175
Signed-off-by: Gabriel Araujo gabe_512@hotmail.com
