### PR TITLE
ART - Actor Network Service - register identity on connection loose

### DIFF
--- a/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-artist-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/artist/developer/bitdubai/version_1/event_handler/ArtistCustomeP2PCompletedConnectionRegistrationEventHandler.java
+++ b/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-artist-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/artist/developer/bitdubai/version_1/event_handler/ArtistCustomeP2PCompletedConnectionRegistrationEventHandler.java
@@ -1,0 +1,40 @@
+package com.bitdubai.fermat_art_plugin.layer.actor_network_service.artist.developer.bitdubai.version_1.event_handler;
+
+import com.bitdubai.fermat_api.FermatException;
+import com.bitdubai.fermat_api.layer.all_definition.components.enums.PlatformComponentType;
+import com.bitdubai.fermat_api.layer.all_definition.enums.ServiceStatus;
+import com.bitdubai.fermat_api.layer.all_definition.events.EventSource;
+import com.bitdubai.fermat_api.layer.all_definition.events.interfaces.FermatEventHandler;
+import com.bitdubai.fermat_art_plugin.layer.actor_network_service.artist.developer.bitdubai.version_1.ArtistActorNetworkServicePluginRoot;
+import com.bitdubai.fermat_p2p_api.layer.all_definition.communication.events.CompleteComponentRegistrationNotificationEvent;
+
+/**
+ * Created by Gabriel Araujo (gabe_512@hotmail.com) on 11/05/16.
+ */
+public class ArtistCustomeP2PCompletedConnectionRegistrationEventHandler implements FermatEventHandler<CompleteComponentRegistrationNotificationEvent> {
+
+    private ArtistActorNetworkServicePluginRoot artistActorNetworkServicePluginRoot;
+
+    public ArtistCustomeP2PCompletedConnectionRegistrationEventHandler(ArtistActorNetworkServicePluginRoot artistActorNetworkServicePluginRoot) {
+        this.artistActorNetworkServicePluginRoot = artistActorNetworkServicePluginRoot;
+    }
+
+    @Override
+    public void handleEvent(CompleteComponentRegistrationNotificationEvent completeComponentRegistrationNotificationEvent) throws FermatException {
+        if(artistActorNetworkServicePluginRoot.getStatus() == ServiceStatus.STARTED){
+            if(artistActorNetworkServicePluginRoot.getNetworkServiceProfile() != null){
+                if(completeComponentRegistrationNotificationEvent != null){
+                    if(completeComponentRegistrationNotificationEvent.getPlatformComponentProfileRegistered().getPlatformComponentType() == PlatformComponentType.COMMUNICATION_CLOUD_CLIENT && completeComponentRegistrationNotificationEvent.getSource() == EventSource.WS_COMMUNICATION_CLOUD_CLIENT_PLUGIN){
+                        artistActorNetworkServicePluginRoot.runExposeIdentityThread();
+                    }
+                }else{
+                    System.out.println("######################\nwrong event");
+                }
+            }else{
+                System.out.println("#####################################\nNetwork Service Profile Null");
+            }
+        }else{
+            System.out.println("####################################\n"+artistActorNetworkServicePluginRoot.getNetworkServiceProfile().getName()+" no started");
+        }
+    }
+}

--- a/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-fan-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/fan/developer/bitdubai/version_1/FanActorNetworkServicePluginRoot.java
+++ b/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-fan-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/fan/developer/bitdubai/version_1/FanActorNetworkServicePluginRoot.java
@@ -6,7 +6,6 @@ import com.bitdubai.fermat_api.CantStartPluginException;
 import com.bitdubai.fermat_api.layer.all_definition.common.system.interfaces.FermatManager;
 import com.bitdubai.fermat_api.layer.all_definition.common.system.utils.PluginVersionReference;
 import com.bitdubai.fermat_api.layer.all_definition.components.enums.PlatformComponentType;
-import com.bitdubai.fermat_api.layer.all_definition.components.interfaces.PlatformComponentProfile;
 import com.bitdubai.fermat_api.layer.all_definition.crypto.asymmetric.ECCKeyPair;
 import com.bitdubai.fermat_api.layer.all_definition.developer.DatabaseManagerForDevelopers;
 import com.bitdubai.fermat_api.layer.all_definition.developer.DeveloperDatabase;
@@ -18,6 +17,7 @@ import com.bitdubai.fermat_api.layer.all_definition.enums.Platforms;
 import com.bitdubai.fermat_api.layer.all_definition.enums.Plugins;
 import com.bitdubai.fermat_api.layer.all_definition.events.EventSource;
 import com.bitdubai.fermat_api.layer.all_definition.events.interfaces.FermatEvent;
+import com.bitdubai.fermat_api.layer.all_definition.events.interfaces.FermatEventListener;
 import com.bitdubai.fermat_api.layer.all_definition.network_service.enums.NetworkServiceType;
 import com.bitdubai.fermat_api.layer.all_definition.util.Version;
 import com.bitdubai.fermat_api.layer.core.PluginInfo;
@@ -36,17 +36,22 @@ import com.bitdubai.fermat_art_api.layer.actor_network_service.interfaces.fan.ut
 import com.bitdubai.fermat_art_api.layer.actor_network_service.interfaces.fan.util.FanExposingData;
 import com.bitdubai.fermat_art_plugin.layer.actor_network_service.fan.developer.bitdubai.version_1.database.FanActorNetworkServiceDao;
 import com.bitdubai.fermat_art_plugin.layer.actor_network_service.fan.developer.bitdubai.version_1.database.FanActorNetworkServiceDeveloperDatabaseFactory;
+import com.bitdubai.fermat_art_plugin.layer.actor_network_service.fan.developer.bitdubai.version_1.event_handler.FanCustomeP2PCompletedConnectionRegistrationEventHandler;
 import com.bitdubai.fermat_art_plugin.layer.actor_network_service.fan.developer.bitdubai.version_1.exceptions.CantHandleNewMessagesException;
 import com.bitdubai.fermat_art_plugin.layer.actor_network_service.fan.developer.bitdubai.version_1.exceptions.CantInitializeDatabaseException;
 import com.bitdubai.fermat_art_plugin.layer.actor_network_service.fan.developer.bitdubai.version_1.messages.InformationMessage;
 import com.bitdubai.fermat_art_plugin.layer.actor_network_service.fan.developer.bitdubai.version_1.messages.NetworkServiceMessage;
 import com.bitdubai.fermat_art_plugin.layer.actor_network_service.fan.developer.bitdubai.version_1.messages.RequestMessage;
 import com.bitdubai.fermat_art_plugin.layer.actor_network_service.fan.developer.bitdubai.version_1.structure.FanActorNetworkServiceManager;
+import com.bitdubai.fermat_p2p_api.layer.all_definition.communication.enums.P2pEventType;
 import com.bitdubai.fermat_p2p_api.layer.all_definition.communication.network_services.base.AbstractNetworkServiceBase;
 import com.bitdubai.fermat_p2p_api.layer.p2p_communication.commons.contents.FermatMessage;
 import com.bitdubai.fermat_api.layer.all_definition.common.system.interfaces.error_manager.enums.UnexpectedPluginExceptionSeverity;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
  * Created by Gabriel Araujo 1/04/2016.
@@ -61,6 +66,13 @@ public class FanActorNetworkServicePluginRoot extends AbstractNetworkServiceBase
     FanActorNetworkServiceDao fanActorNetworkServiceDao;
     
     FanActorNetworkServiceManager fanActorNetworkServiceManager;
+
+    /**
+     * Hold the listeners references
+     */
+    private List<FermatEventListener> listenersAdded;
+
+    private ExecutorService executor;
     /**
      * Constructor of the Network Service.
      */
@@ -74,6 +86,9 @@ public class FanActorNetworkServicePluginRoot extends AbstractNetworkServiceBase
                 "Fan",
                 null
         );
+
+        listenersAdded = new ArrayList<>();
+        executor = Executors.newSingleThreadExecutor();
     }
 
     /**
@@ -96,6 +111,11 @@ public class FanActorNetworkServicePluginRoot extends AbstractNetworkServiceBase
                     getPluginVersionReference()
             );
 
+            FermatEventListener fermatEventListener = eventManager.getNewListener(P2pEventType.COMPLETE_COMPONENT_REGISTRATION_NOTIFICATION);
+            fermatEventListener.setEventHandler(new FanCustomeP2PCompletedConnectionRegistrationEventHandler(this));
+            eventManager.addListener(fermatEventListener);
+            listenersAdded.add(fermatEventListener);
+
         } catch(final CantInitializeDatabaseException e) {
 
             errorManager.reportUnexpectedPluginException(this.getPluginVersionReference(), UnexpectedPluginExceptionSeverity.DISABLES_THIS_PLUGIN, e);
@@ -114,6 +134,8 @@ public class FanActorNetworkServicePluginRoot extends AbstractNetworkServiceBase
         fanActorNetworkServiceManager.setPlatformComponentProfile(null);
         getCommunicationNetworkServiceConnectionManager().pause();
 
+        executor.shutdownNow();
+
         super.pause();
     }
 
@@ -122,7 +144,7 @@ public class FanActorNetworkServicePluginRoot extends AbstractNetworkServiceBase
 
         // resume connections manager.
         getCommunicationNetworkServiceConnectionManager().resume();
-
+        executor = Executors.newSingleThreadExecutor();
         super.resume();
     }
 
@@ -131,7 +153,7 @@ public class FanActorNetworkServicePluginRoot extends AbstractNetworkServiceBase
 
         fanActorNetworkServiceManager.setPlatformComponentProfile(null);
         getCommunicationNetworkServiceConnectionManager().stop();
-
+        executor.shutdownNow();
         super.stop();
     }
 
@@ -350,30 +372,33 @@ public class FanActorNetworkServicePluginRoot extends AbstractNetworkServiceBase
         runExposeIdentityThread();
     }
 
-    private void runExposeIdentityThread(){
+    public final void runExposeIdentityThread(){
+
         final PluginVersionReference pluginReference = getPluginVersionReference();
-        Thread exposeIdentities = new Thread(new Runnable() {
+
+        executor.submit(new Runnable() {
             @Override
             public void run() {
                 try {
+                    Thread.sleep(3000);
                     fanActorNetworkServiceManager.exposeIdentitiesInWait();
-                } catch (CantExposeIdentityException e) {
+                } catch (CantExposeIdentityException | InterruptedException e) {
                     errorManager.reportUnexpectedPluginException(pluginReference, UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN, e);
+                } catch (Exception e) {
+                    e.printStackTrace();
                 }
             }
-        }, "REGISTER ARTIST IDENTITY CACHE");
-
-        exposeIdentities.start();
+        });
     }
 
 
-    private void testCreateAndList(){
+    private void testCreateAndList() {
         ECCKeyPair identity = new ECCKeyPair();
         try {
             fanActorNetworkServiceManager.exposeIdentity(new FanExposingData(identity.getPublicKey(), "El Gabo fan", ""));
             ActorSearch<FanExposingData> artistActorNetworkServiceSearch = fanActorNetworkServiceManager.getSearch();
             List<FanExposingData> artistExposingDatas = artistActorNetworkServiceSearch.getResult(PlatformComponentType.ART_ARTIST);
-            for (FanExposingData artistExposingData:
+            for (FanExposingData artistExposingData :
                     artistExposingDatas) {
                 System.out.println("#############################\nArtistas registrados:"+artistExposingData.getAlias()+"\nPublicKey:"+artistExposingData.getPublicKey());
             }

--- a/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-fan-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/fan/developer/bitdubai/version_1/event_handler/FanCustomeP2PCompletedConnectionRegistrationEventHandler.java
+++ b/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-fan-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/fan/developer/bitdubai/version_1/event_handler/FanCustomeP2PCompletedConnectionRegistrationEventHandler.java
@@ -1,0 +1,40 @@
+package com.bitdubai.fermat_art_plugin.layer.actor_network_service.fan.developer.bitdubai.version_1.event_handler;
+
+import com.bitdubai.fermat_api.FermatException;
+import com.bitdubai.fermat_api.layer.all_definition.components.enums.PlatformComponentType;
+import com.bitdubai.fermat_api.layer.all_definition.enums.ServiceStatus;
+import com.bitdubai.fermat_api.layer.all_definition.events.EventSource;
+import com.bitdubai.fermat_api.layer.all_definition.events.interfaces.FermatEventHandler;
+import com.bitdubai.fermat_art_plugin.layer.actor_network_service.fan.developer.bitdubai.version_1.FanActorNetworkServicePluginRoot;
+import com.bitdubai.fermat_p2p_api.layer.all_definition.communication.events.CompleteComponentRegistrationNotificationEvent;
+
+/**
+ * Created by Gabriel Araujo (gabe_512@hotmail.com) on 11/05/16.
+ */
+public class FanCustomeP2PCompletedConnectionRegistrationEventHandler implements FermatEventHandler<CompleteComponentRegistrationNotificationEvent> {
+
+    private FanActorNetworkServicePluginRoot fanActorNetworkServicePluginRoot;
+
+    public FanCustomeP2PCompletedConnectionRegistrationEventHandler(FanActorNetworkServicePluginRoot fanActorNetworkServicePluginRoot) {
+        this.fanActorNetworkServicePluginRoot = fanActorNetworkServicePluginRoot;
+    }
+
+    @Override
+    public void handleEvent(CompleteComponentRegistrationNotificationEvent completeComponentRegistrationNotificationEvent) throws FermatException {
+        if(fanActorNetworkServicePluginRoot.getStatus() == ServiceStatus.STARTED){
+            if(fanActorNetworkServicePluginRoot.getNetworkServiceProfile() != null){
+                if(completeComponentRegistrationNotificationEvent != null){
+                    if(completeComponentRegistrationNotificationEvent.getPlatformComponentProfileRegistered().getPlatformComponentType() == PlatformComponentType.COMMUNICATION_CLOUD_CLIENT && completeComponentRegistrationNotificationEvent.getSource() == EventSource.WS_COMMUNICATION_CLOUD_CLIENT_PLUGIN){
+                        fanActorNetworkServicePluginRoot.runExposeIdentityThread();
+                    }
+                }else{
+                    System.out.println("######################\nwrong event");
+                }
+            }else{
+                System.out.println("#####################################\nNetwork Service Profile Null");
+            }
+        }else{
+            System.out.println("####################################\n"+ fanActorNetworkServicePluginRoot.getNetworkServiceProfile().getName()+" no started");
+        }
+    }
+}


### PR DESCRIPTION
I added a special handler to CompleteComponentRegistrationNotificationEvent from cloud client
in order to launch a thread to register identities in cache once the connection is lost.

Include in: fix #6175

Signed-off-by: Gabriel Araujo gabe_512@hotmail.com
