### PR TITLE
ART - Actor Network Service - register identity on connection loose

### DIFF
--- a/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-artist-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/artist/developer/bitdubai/version_1/ArtistActorNetworkServicePluginRoot.java
+++ b/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-artist-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/artist/developer/bitdubai/version_1/ArtistActorNetworkServicePluginRoot.java
@@ -457,20 +457,21 @@ public class ArtistActorNetworkServicePluginRoot extends AbstractNetworkServiceB
 
         final PluginVersionReference pluginReference = getPluginVersionReference();
 
-        executor.submit(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    Thread.sleep(3000);
-                    artistActorNetworkServiceManager.exposeIdentitiesInWait();
-                } catch (CantExposeIdentityException | InterruptedException e) {
-                    errorManager.reportUnexpectedPluginException(pluginReference, UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN, e);
-                } catch (Exception e) {
-                    e.printStackTrace();
+        if(artistActorNetworkServiceManager.areIdentitiesToExpose()){
+            executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        Thread.sleep(3000);
+                        artistActorNetworkServiceManager.exposeIdentitiesInWait();
+                    } catch (CantExposeIdentityException | InterruptedException e) {
+                        errorManager.reportUnexpectedPluginException(pluginReference, UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN, e);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
                 }
-            }
-        });
-
+            });
+        }
     }
     @Override
     protected void onClientSuccessfulReconnect() {

--- a/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-artist-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/artist/developer/bitdubai/version_1/structure/ArtistActorNetworkServiceManager.java
+++ b/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-artist-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/artist/developer/bitdubai/version_1/structure/ArtistActorNetworkServiceManager.java
@@ -93,6 +93,9 @@ public final class ArtistActorNetworkServiceManager implements ArtistManager {
     }
 
 
+    public final boolean areIdentitiesToExpose(){
+        return (!Validate.isObjectNull(artistsToExpose) && artistsToExpose.size() > 0);
+    }
     @Override
     public final void exposeIdentity(final ArtistExposingData artist) throws CantExposeIdentityException {
 

--- a/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-fan-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/fan/developer/bitdubai/version_1/FanActorNetworkServicePluginRoot.java
+++ b/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-fan-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/fan/developer/bitdubai/version_1/FanActorNetworkServicePluginRoot.java
@@ -376,19 +376,21 @@ public class FanActorNetworkServicePluginRoot extends AbstractNetworkServiceBase
 
         final PluginVersionReference pluginReference = getPluginVersionReference();
 
-        executor.submit(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    Thread.sleep(3000);
-                    fanActorNetworkServiceManager.exposeIdentitiesInWait();
-                } catch (CantExposeIdentityException | InterruptedException e) {
-                    errorManager.reportUnexpectedPluginException(pluginReference, UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN, e);
-                } catch (Exception e) {
-                    e.printStackTrace();
+        if(fanActorNetworkServiceManager.areIdentityToExpose()){
+            executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        Thread.sleep(3000);
+                        fanActorNetworkServiceManager.exposeIdentitiesInWait();
+                    } catch (CantExposeIdentityException | InterruptedException e) {
+                        errorManager.reportUnexpectedPluginException(pluginReference, UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN, e);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
                 }
-            }
-        });
+            });
+        }
     }
 
 

--- a/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-fan-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/fan/developer/bitdubai/version_1/structure/FanActorNetworkServiceManager.java
+++ b/ART/plugin/actor_network_service/fermat-art-plugin-actor-network-service-fan-bitdubai/src/main/java/com/bitdubai/fermat_art_plugin/layer/actor_network_service/fan/developer/bitdubai/version_1/structure/FanActorNetworkServiceManager.java
@@ -91,6 +91,10 @@ public final class FanActorNetworkServiceManager implements FanManager {
             }
         }
     }
+
+    public final boolean areIdentityToExpose(){
+        return (!Validate.isObjectNull(fansToExpose) && fansToExpose.size() > 0);
+    }
     @Override
     public final void exposeIdentity(final FanExposingData fan) throws CantExposeIdentityException {
 


### PR DESCRIPTION
Added method in manager to avoid launch the thread when not needed, as when there is not identities to register.

Include in: #6175

Signed-off-by: Gabriel Araujo gabe_512@hotmail.com
