### PR TITLE
Fix: Delete song in fan wallet and download exception

### DIFF
--- a/TKY/android/reference_wallet/fermat-tky-android-reference-wallet-fan-wallet-bitdubai/src/main/java/com/bitdubai/reference_wallet/fan_wallet/fragments/SongFragment.java
+++ b/TKY/android/reference_wallet/fermat-tky-android-reference-wallet-fan-wallet-bitdubai/src/main/java/com/bitdubai/reference_wallet/fan_wallet/fragments/SongFragment.java
@@ -542,9 +542,14 @@ public class SongFragment extends AbstractFermatFragment  {
         String databaseInfo;
         List<String> listComposerAndSongNameOnView=new ArrayList<>();
         List<WalletSong> songsInDatabase=new ArrayList<>();
+        List<WalletSong> songsInDatabaseDelete=new ArrayList<>();
 
         try {
             songsInDatabase = fanWalletModule.getAvailableSongs();
+            songsInDatabaseDelete=fanWalletModule.getDeletedSongs();
+            for(WalletSong walletSong:songsInDatabaseDelete){
+                songsInDatabase.add(walletSong);
+            }
         } catch (CantGetSongListException e) {
             e.printStackTrace();
         }
@@ -871,9 +876,14 @@ public class SongFragment extends AbstractFermatFragment  {
         items.get(position).setStatus(SongStatus.CANCELLED.getFriendlyName());
         adapter.setFilter(items.get(position),true,position);
     }
-    // TODO: 04/04/16 what happen here?
+
     void downloadproblem(int position){
-        //TODO: to implement
+        System.out.println("TKY_DOWNLOAD_EXCEPTION_WHILE_DOWNLOAD: "+items.get(position).getSong_name());
+        Toast.makeText(
+                view.getContext(),
+                "Problem with Download of\n"+items.get(position).getSong_name(),
+                Toast.LENGTH_SHORT)
+                .show();
     }
 
     void playSong(){
@@ -1011,9 +1021,7 @@ public class SongFragment extends AbstractFermatFragment  {
 
         }
 
-        /**
-         * Se ejecuta después de "onPreExecute". Se puede llamar al hilo Principal con el método "publishProgress" que ejecuta el método "onProgressUpdate" en hilo Principal
-         */
+
         @Override
         protected Boolean doInBackground(Void... notUsingObject) {
 


### PR DESCRIPTION
When the user deleted the song and left the fermat app, and later 
reopen the fan wallet, the deleted song didn't appear resolve #565

When the fermat bundle in the broadcast came with the download exception 
the app show a toast to notify the user that an error occur resolve #6239
